### PR TITLE
[naive impl] Add resolve command logic

### DIFF
--- a/mvr-cli/src/commands.rs
+++ b/mvr-cli/src/commands.rs
@@ -28,6 +28,7 @@ pub enum Command {
     Register {
         name: String,
     },
+    /// Resolve a name to an address and show all known related metadata.
     Resolve {
         name: String,
     },
@@ -41,7 +42,7 @@ pub enum CommandOutput {
     List(Vec<App>),
     Register,
     #[serde(rename = "resolved_name")]
-    Resolve,
+    Resolve(Option<App>),
 }
 
 #[derive(Serialize)]
@@ -76,7 +77,13 @@ impl Display for CommandOutput {
                 Ok(())
             }
             CommandOutput::Register => write!(f, "Registered"),
-            CommandOutput::Resolve => write!(f, "Resolved"),
+            CommandOutput::Resolve(app) => {
+                if let Some(app) = app {
+                    writeln!(f, "{}", app)
+                } else {
+                    write!(f, "No address found for the given name")
+                }
+            }
         }
     }
 }

--- a/mvr-cli/src/lib.rs
+++ b/mvr-cli/src/lib.rs
@@ -1274,6 +1274,10 @@ pub async fn subcommand_register_name(_name: &str) -> Result<CommandOutput> {
 
 /// resolve a .move name to an address. E.g., `nft@sample` => 0x... cf. subcommand_list implementation.
 pub async fn subcommand_resolve_name(_name: &str) -> Result<CommandOutput> {
-    println!("tbd!");
-    Ok(CommandOutput::Resolve)
+    let list = subcommand_list().await?;
+    let app = match list {
+        CommandOutput::List(list) => list.into_iter().find(|f| f.name == _name),
+        _ => None,
+    };
+    Ok(CommandOutput::Resolve(app))
 }


### PR DESCRIPTION
Adds a naive implementation for resolve command logic. This should be improved later on.

```
➜  mvr-cli git:(main) ./target/debug/mvr resolve @mvr-tst/first-app
 Package:  @mvr-tst/first-app 

  [testnet]
     Registered address not found    

  [mainnet]
     Package Address  0xd94df18bd28e31c65241e2db942920cd6d92f69531b7bff5eccebdaf8fcfc8bf 
     Upgrade Cap      0x764aa368ce52fd7e5612fc6c244b01b0eea232cbdc22a1661785d24e2d252a3e 
     Version          1                                                                  
     Repository       https://github.com/MystenLabs/demo-package-for-testing             
     Tag              main                                                               
     Path             0x7328/demo-mainnet                  
```