### PR TITLE
Add release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -84,18 +84,26 @@ jobs:
         run: |
           [ -f ~/.cargo/env ] && source ~/.cargo/env ; cd mvr-cli && cargo build --release
 
-      - name: Rename and compress binaries for ${{ matrix.os }}
-        shell: bash
-        run: |
-          mkdir -p ${{ env.TMP_BUILD_DIR }}
-          export binary="mvr"
-          mv mvr-cli/target/release/${binary}${{ env.extension }} ${{ env.TMP_BUILD_DIR }}/${binary}-${{ env.os_type }}${{ env.extension }}
-          done
-
       - name: Attach artifacts to ${{ env.mvr_tag }} release in GH
         uses: softprops/action-gh-release@de2c0eb89ae2a093876385947365aca7b0e5f844 # pin@v1
         with:
           files: |
-            ./tmp/mvr-${{ env.os_type }}${{ env.extension }}
+            ./mvr-cli/target/release/mvr-${{ env.os_type }}${{ env.extension }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      # - name: Rename and compress binaries for ${{ matrix.os }}
+      #   shell: bash
+      #   run: |
+      #     mkdir -p ${{ env.TMP_BUILD_DIR }}
+      #     export binary="mvr"
+      #     mv mvr-cli/target/release/${binary}${{ env.extension }} ${{ env.TMP_BUILD_DIR }}/${binary}-${{ env.os_type }}${{ env.extension }}
+      #     done
+      #
+      # - name: Attach artifacts to ${{ env.mvr_tag }} release in GH
+      #   uses: softprops/action-gh-release@de2c0eb89ae2a093876385947365aca7b0e5f844 # pin@v1
+      #   with:
+      #     files: |
+      #       ./tmp/mvr-${{ env.os_type }}${{ env.extension }}
+      #   env:
+      #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Two working modes:
1) when a release is published, it will build the release binaries and attach them to the release.
Or
2) manual trigger the build via GitHub actions.

Both require a valid tag: `v0.0.1` to be pushed in the repo, which indicates the version at that specific commit.