### PR TITLE
mvr: constants for TOML access and parse with reference implementation

### DIFF
--- a/mvr-cli/Cargo.lock
+++ b/mvr-cli/Cargo.lock
@@ -3538,6 +3538,7 @@ dependencies = [
  "clap",
  "comfy-table",
  "expect-test",
+ "once_cell",
  "regex",
  "reqwest 0.12.7",
  "serde",
@@ -3895,9 +3896,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.19.0"
+version = "1.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
+checksum = "1261fe7e33c73b354eab43b1273a57c8f967d0391e80353e51f764ac02cf6775"
 
 [[package]]
 name = "opaque-debug"

--- a/mvr-cli/Cargo.toml
+++ b/mvr-cli/Cargo.toml
@@ -32,6 +32,7 @@ toml = "0.8.19"
 regex = "1.10.5"
 yansi = "1.0.1"
 comfy-table = "7.1.1"
+once_cell = "1.20.2"
 
 [dev-dependencies]
 expect-test = "1.1"

--- a/mvr-cli/src/tests/unit_tests.rs
+++ b/mvr-cli/src/tests/unit_tests.rs
@@ -154,15 +154,20 @@ async fn test_parse_package_version() -> Result<()> {
     let result = parse_package_version("@foo/bar/baz");
     expect![[r#"
         Err(
-            "\u{1b}[31mCannot parse version \"\u{1b}[0m\u{1b}[1;31mbaz\u{1b}[0m\u{1b}[31m\". Version must be 1 or greater.\u{1b}[0m",
+            "Invalid name format: @foo/bar/baz",
         )
     "#]]
     .assert_debug_eq(&result);
 
     let result = parse_package_version("@foo/bar/0");
     expect![[r#"
-        Err(
-            "\u{1b}[31mInvalid version number\u{1b}[0m \u{1b}[1;31m0\u{1b}[0m\u{1b}[31m. Version must be 1 or greater.\u{1b}[0m",
+        Ok(
+            (
+                "@foo/bar",
+                Some(
+                    0,
+                ),
+            ),
         )
     "#]]
     .assert_debug_eq(&result);


### PR DESCRIPTION
Two commits:

- ed039194e5a93e34b411208c263f21fb2d3c94e2 use constants to access TOML members (follow up from feedback)
- 8d386a42e698ac5b43b2451a427a9904cb81ebfb use [reference implementation](https://github.com/MystenLabs/sui/blob/75264b965769e339e3d478ab8eb5b16e7280037c/crates/sui-graphql-rpc/src/types/move_registry/on_chain.rs#L137C1-L171C2) to parse move name / version (follow up from feedback)