### PR TITLE
Introduce MVR types

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,8 @@ resolver = "2"
 members = [
     "mvr-cli",
     "crates/mvr-indexer",
-    "crates/mvr-schema"
+    "crates/mvr-schema",
+    "crates/mvr-types"
 ]
 
 [workspace.dependencies]
@@ -15,3 +16,5 @@ chrono = "0.4.39"
 diesel = "2.2.7"
 diesel-async = "0.5.2"
 anyhow = "1.0.95"
+thiserror = "2.0.11"
+once_cell = "1.20.3"

--- a/crates/mvr-types/Cargo.toml
+++ b/crates/mvr-types/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "mvr-types"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+sui-types = { git = "https://github.com/MystenLabs/sui.git" }
+serde = { workspace = true, features = ["derive"] }
+anyhow.workspace = true
+thiserror.workspace = true
+once_cell.workspace = true
+regex = "1.11.1"

--- a/crates/mvr-types/src/errors.rs
+++ b/crates/mvr-types/src/errors.rs
@@ -1,0 +1,33 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(thiserror::Error, Debug, Serialize, Deserialize, Clone, Eq, PartialEq)]
+pub enum MoveRegistryError {
+    // The name was found in the service, but it is not a valid name.
+    #[error("Move Registry: The request name {0} is malformed.")]
+    InvalidName(String),
+
+    #[error("Move Registry: The request type {0} is malformed.")]
+    InvalidType(String),
+
+    #[error("Move Registry: The name {0} was not found.")]
+    NameNotFound(String),
+
+    #[error("Move Registry: Invalid version")]
+    InvalidVersion,
+}
+
+#[derive(thiserror::Error, Debug, Serialize, Deserialize, Clone, Eq, PartialEq)]
+pub enum NameServiceError {
+    #[error("Name Service: String length: {0} exceeds maximum allowed length: {1}")]
+    ExceedsMaxLength(usize, usize),
+    #[error("Name Service: String length: {0} outside of valid range: [{1}, {2}]")]
+    InvalidLength(usize, usize, usize),
+    #[error("Name Service: Hyphens are not allowed as the first or last character")]
+    InvalidHyphens,
+    #[error("Name Service: Only lowercase letters, numbers, and hyphens are allowed")]
+    InvalidUnderscore,
+    #[error("Name Service: Domain must contain at least one label")]
+    LabelsEmpty,
+    #[error("Name Service: Domain must include only one separator")]
+    InvalidSeparator,
+}

--- a/crates/mvr-types/src/lib.rs
+++ b/crates/mvr-types/src/lib.rs
@@ -1,0 +1,4 @@
+pub mod errors;
+pub mod name;
+pub mod name_service;
+pub mod named_type;

--- a/crates/mvr-types/src/name.rs
+++ b/crates/mvr-types/src/name.rs
@@ -1,0 +1,271 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use core::fmt;
+use std::str::FromStr;
+
+use once_cell::sync::Lazy;
+use regex::Regex;
+use serde::{Deserialize, Serialize};
+
+use super::{
+    errors::MoveRegistryError,
+    name_service::{validate_label, Domain, DomainFormat},
+};
+
+/// Regex to parse a dot move name. Version is optional (defaults to latest).
+/// For versioned format, the expected format is `@org/app/1` (1 == version).
+/// For an unversioned format, the expected format is `@org/app`.
+///
+/// The unbound regex can be used to search matches in a type tag.
+/// Use `VERSIONED_NAME_REGEX` for parsing a single name from a str.
+const VERSIONED_NAME_UNBOUND_REGEX: &str =
+    concat!(r"([a-z0-9.\-@]*)", r"\/", "([a-z0-9.-]*)", r"(?:\/(\d+))?",);
+
+/// Regex to parse a dot move name. Version is optional (defaults to latest).
+/// For versioned format, the expected format is `@org/app/1`.
+/// For an unversioned format, the expected format is `@org/app`.
+///
+/// This regex is used to parse a single name (does not do type_tag matching).
+/// Use `VERSIONED_NAME_UNBOUND_REGEX` for type tag matching.
+const VERSIONED_NAME_REGEX: &str = concat!(
+    "^",
+    r"([a-z0-9.\-@]*)",
+    r"\/",
+    "([a-z0-9.-]*)",
+    r"(?:\/(\d+))?",
+    "$"
+);
+
+/// A regular expression that detects all possible dot move names in a type tag.
+pub(crate) static VERSIONED_NAME_UNBOUND_REG: Lazy<Regex> =
+    Lazy::new(|| Regex::new(VERSIONED_NAME_UNBOUND_REGEX).unwrap());
+
+/// A regular expression that detects a single name in the format `@org/app/1`.
+pub(crate) static VERSIONED_NAME_REG: Lazy<Regex> =
+    Lazy::new(|| Regex::new(VERSIONED_NAME_REGEX).unwrap());
+
+#[derive(Debug, Serialize, Deserialize, Hash, Clone, Eq, PartialEq)]
+pub struct VersionedName {
+    /// A version name defaults at None, which means we need the latest version.
+    pub version: Option<u64>,
+    /// The on-chain `Name` object that represents the move registry name.
+    pub name: Name,
+}
+
+/// Attention: The format of this struct should not change unless the on-chain format changes,
+/// as we define it to deserialize on-chain data.
+#[derive(Debug, Serialize, Deserialize, Hash, Clone, Eq, PartialEq)]
+pub struct Name {
+    pub org: Domain,
+    pub app: Vec<String>,
+}
+
+impl Name {
+    pub fn new(org: Domain, app: &str) -> Self {
+        Self {
+            org,
+            app: vec![app.to_string()],
+        }
+    }
+}
+
+impl fmt::Display for Name {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        // We use to_string() to check on-chain state and parse on-chain data
+        // so we should always default to DOT format.
+        let output = self.org.format(DomainFormat::At);
+        f.write_str(&output)?;
+
+        f.write_str("/")?;
+
+        let app_str = self
+            .app
+            .iter()
+            .rev()
+            .map(|s| s.to_string())
+            .collect::<Vec<_>>()
+            .join("/");
+
+        f.write_str(&app_str)?;
+
+        Ok(())
+    }
+}
+
+impl fmt::Display for VersionedName {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.name)?;
+        if let Some(version) = self.version {
+            write!(f, "/{}", version)?;
+        }
+        Ok(())
+    }
+}
+
+impl FromStr for VersionedName {
+    type Err = MoveRegistryError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let Some(caps) = VERSIONED_NAME_REG.captures(s) else {
+            return Err(MoveRegistryError::InvalidName(s.to_string()));
+        };
+
+        let Some(org_name) = caps.get(1).map(|x| x.as_str()) else {
+            return Err(MoveRegistryError::InvalidName(s.to_string()));
+        };
+
+        // validate org_name by trying to cast our input to a Domain.
+        let domain = Domain::from_str(org_name)
+            .map_err(|_| MoveRegistryError::InvalidName(s.to_string()))?;
+
+        let Some(app_name) = caps.get(2).map(|x| x.as_str()) else {
+            return Err(MoveRegistryError::InvalidName(s.to_string()));
+        };
+
+        // Validate our app's label.
+        validate_label(app_name).map_err(|_| MoveRegistryError::InvalidName(s.to_string()))?;
+
+        let version: Option<u64> = caps
+            .get(3)
+            .map(|x| x.as_str().parse())
+            .transpose()
+            .map_err(|_| MoveRegistryError::InvalidVersion)?;
+
+        Ok(Self {
+            version,
+            name: Name::new(domain, app_name),
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{name::Name, name_service::Domain};
+
+    use super::VersionedName;
+    use std::str::FromStr;
+
+    #[test]
+    fn to_string() {
+        let name = Name {
+            org: Domain::from_str("test.sui").unwrap(),
+            app: vec!["app".to_string()],
+        };
+        assert_eq!(name.to_string(), "@test/app");
+
+        let name = Name {
+            org: Domain::from_str("inner.test.sui").unwrap(),
+            app: vec!["app".to_string()],
+        };
+
+        assert_eq!(name.to_string(), "inner@test/app");
+    }
+
+    #[test]
+    fn parse_some_names() {
+        let versioned = VersionedName::from_str("@org/app/1").unwrap();
+        assert!(versioned.version.is_some_and(|x| x == 1));
+
+        assert!(VersionedName::from_str("@org/app/34")
+            .unwrap()
+            .version
+            .is_some_and(|x| x == 34));
+        assert!(VersionedName::from_str("@org/app")
+            .unwrap()
+            .version
+            .is_none());
+
+        let ok_names = vec![
+            "@org/1-app/1",
+            "@org/1-app/34",
+            "@org/1-app",
+            "nested@org/app",
+            "even.more.nested@org/app",
+        ];
+
+        let composite_ok_names = vec![
+            format!("@org/{}/1", generate_fixed_string(63)),
+            format!("@org/{}-app/34", generate_fixed_string(59)),
+            format!(
+                "@{}/{}",
+                generate_fixed_string(63),
+                generate_fixed_string(63)
+            ),
+            format!(
+                "@{}/{}-{}",
+                generate_fixed_string(63),
+                generate_fixed_string(30),
+                generate_fixed_string(30)
+            ),
+        ];
+
+        for name in ok_names {
+            assert!(VersionedName::from_str(name).is_ok());
+        }
+        for name in composite_ok_names {
+            assert!(VersionedName::from_str(&name).is_ok());
+        }
+
+        let not_ok_names = vec![
+            "@org/-app",
+            "@org/1.app",
+            "@org/app-",
+            "@org/app--",
+            "@org/app?",
+            "@org/app/",
+            "@org/app/v",
+            "@org/app/veh",
+            "@org",
+            "@/veh/app",
+            "app",
+            "@",
+            "@org/ap@",
+            "!org/ap",
+            "#org/ap",
+            "@org/ap#org",
+            "org/@app",
+            "",
+            " ",
+        ];
+        let composite_err_names = vec![
+            format!(
+                "@{}{}--/{}",
+                generate_fixed_string(10),
+                generate_fixed_string(10),
+                generate_fixed_string(63)
+            ),
+            format!(
+                "@--{}-{}/{}",
+                generate_fixed_string(10),
+                generate_fixed_string(10),
+                generate_fixed_string(63)
+            ),
+            format!(
+                "@{}/--{}{}",
+                generate_fixed_string(63),
+                generate_fixed_string(30),
+                generate_fixed_string(30)
+            ),
+        ];
+
+        for name in not_ok_names {
+            assert!(VersionedName::from_str(name).is_err());
+        }
+        for name in composite_err_names {
+            assert!(VersionedName::from_str(&name).is_err());
+        }
+    }
+
+    fn generate_fixed_string(len: usize) -> String {
+        // Define the characters to use in the string
+        let chars = "abcdefghijklmnopqrstuvwxyz0123456789";
+        // Repeat the characters to ensure we have at least 63 characters
+        let repeated_chars = chars.repeat(3);
+
+        // Take the first 63 characters to form the string
+        let fixed_string = &repeated_chars[0..len];
+
+        fixed_string.to_string()
+    }
+}

--- a/crates/mvr-types/src/name_service.rs
+++ b/crates/mvr-types/src/name_service.rs
@@ -1,0 +1,173 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use serde::{Deserialize, Serialize};
+use std::fmt;
+use std::str::FromStr;
+
+use crate::errors::NameServiceError;
+
+const DEFAULT_TLD: &str = "sui";
+const ACCEPTED_SEPARATORS: [char; 2] = ['.', '*'];
+const SUI_NEW_FORMAT_SEPARATOR: char = '@';
+
+/// Two different view options for a domain.
+/// `At` -> `test@example` | `Dot` -> `test.example.sui`
+#[derive(Clone, Eq, PartialEq, Debug)]
+pub enum DomainFormat {
+    At,
+    Dot,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone, Eq, Hash, PartialEq)]
+pub struct Domain {
+    labels: Vec<String>,
+}
+
+impl Domain {
+    /// Formats a domain into a string based on the available output formats.
+    /// The default separator is `.`
+    pub fn format(&self, format: DomainFormat) -> String {
+        let mut labels = self.labels.clone();
+        let sep = &ACCEPTED_SEPARATORS[0].to_string();
+        labels.reverse();
+
+        if format == DomainFormat::Dot {
+            return labels.join(sep);
+        };
+
+        // SAFETY: This is a safe operation because we only allow a
+        // domain's label vector size to be >= 2 (see `Domain::from_str`)
+        let _tld = labels.pop();
+        let sld = labels.pop().unwrap();
+
+        format!("{}{}{}", labels.join(sep), SUI_NEW_FORMAT_SEPARATOR, sld)
+    }
+}
+
+impl FromStr for Domain {
+    type Err = NameServiceError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        /// The maximum length of a full domain
+        const MAX_DOMAIN_LENGTH: usize = 200;
+
+        if s.len() > MAX_DOMAIN_LENGTH {
+            return Err(NameServiceError::ExceedsMaxLength(
+                s.len(),
+                MAX_DOMAIN_LENGTH,
+            ));
+        }
+        let separator = separator(s)?;
+
+        let formatted_string = convert_from_new_format(s, &separator)?;
+
+        let labels = formatted_string
+            .split(separator)
+            .rev()
+            .map(validate_label)
+            .collect::<Result<Vec<_>, Self::Err>>()?;
+
+        // A valid domain in our system has at least a TLD and an SLD (len == 2).
+        if labels.len() < 2 {
+            return Err(NameServiceError::LabelsEmpty);
+        }
+
+        let labels = labels.into_iter().map(ToOwned::to_owned).collect();
+        Ok(Domain { labels })
+    }
+}
+
+/// Parses a separator from the domain string input.
+/// E.g.  `example.sui` -> `.` | example*sui -> `@` | `example*sui` -> `*`
+fn separator(s: &str) -> Result<char, NameServiceError> {
+    let mut domain_separator: Option<char> = None;
+
+    for separator in ACCEPTED_SEPARATORS.iter() {
+        if s.contains(*separator) {
+            if domain_separator.is_some() {
+                return Err(NameServiceError::InvalidSeparator);
+            }
+
+            domain_separator = Some(*separator);
+        }
+    }
+
+    match domain_separator {
+        Some(separator) => Ok(separator),
+        None => Ok(ACCEPTED_SEPARATORS[0]),
+    }
+}
+
+/// Converts @label ending to label{separator}sui ending.
+///
+/// E.g. `@example` -> `example.sui` | `test@example` -> `test.example.sui`
+fn convert_from_new_format(s: &str, separator: &char) -> Result<String, NameServiceError> {
+    let mut splits = s.split(SUI_NEW_FORMAT_SEPARATOR);
+
+    let Some(before) = splits.next() else {
+        return Err(NameServiceError::InvalidSeparator);
+    };
+
+    let Some(after) = splits.next() else {
+        return Ok(before.to_string());
+    };
+
+    if splits.next().is_some() || after.contains(*separator) || after.is_empty() {
+        return Err(NameServiceError::InvalidSeparator);
+    }
+
+    let mut parts = vec![];
+
+    if !before.is_empty() {
+        parts.push(before);
+    }
+
+    parts.push(after);
+    parts.push(DEFAULT_TLD);
+
+    Ok(parts.join(&separator.to_string()))
+}
+
+pub fn validate_label(label: &str) -> Result<&str, NameServiceError> {
+    const MIN_LABEL_LENGTH: usize = 1;
+    const MAX_LABEL_LENGTH: usize = 63;
+    let bytes = label.as_bytes();
+    let len = bytes.len();
+
+    if !(MIN_LABEL_LENGTH..=MAX_LABEL_LENGTH).contains(&len) {
+        return Err(NameServiceError::InvalidLength(
+            len,
+            MIN_LABEL_LENGTH,
+            MAX_LABEL_LENGTH,
+        ));
+    }
+
+    for (i, character) in bytes.iter().enumerate() {
+        let is_valid_character = match character {
+            b'a'..=b'z' => true,
+            b'0'..=b'9' => true,
+            b'-' if i != 0 && i != len - 1 => true,
+            _ => false,
+        };
+
+        if !is_valid_character {
+            match character {
+                b'-' => return Err(NameServiceError::InvalidHyphens),
+                _ => return Err(NameServiceError::InvalidUnderscore),
+            }
+        };
+    }
+    Ok(label)
+}
+
+impl fmt::Display for Domain {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        // We use to_string() to check on-chain state and parse on-chain data
+        // so we should always default to DOT format.
+        let output = self.format(DomainFormat::Dot);
+        f.write_str(&output)?;
+
+        Ok(())
+    }
+}

--- a/crates/mvr-types/src/named_type.rs
+++ b/crates/mvr-types/src/named_type.rs
@@ -1,0 +1,190 @@
+use std::{collections::HashMap, str::FromStr};
+
+use anyhow::anyhow;
+use regex::{Captures, Regex};
+use sui_types::{base_types::ObjectID, TypeTag};
+
+use crate::name::{VersionedName, VERSIONED_NAME_UNBOUND_REG};
+
+use super::errors::MoveRegistryError;
+
+pub struct NamedType;
+
+impl NamedType {
+    pub fn replace_names(
+        type_name: &str,
+        names: &HashMap<String, ObjectID>,
+    ) -> Result<String, anyhow::Error> {
+        let struct_tag_str = replace_all_result(
+            &VERSIONED_NAME_UNBOUND_REG,
+            type_name,
+            |m: &regex::Captures| {
+                // SAFETY: we know that the regex will have a match on position 0.
+                let name = m.get(0).unwrap().as_str();
+
+                // if we are misusing the function, and we cannot find the name in the hashmap,
+                // we return an empty string, which will make the type tag invalid.
+                if let Some(addr) = names.get(name) {
+                    Ok(addr.to_string())
+                } else {
+                    Err(anyhow!("Name not found: {}", name))
+                }
+            },
+        )?;
+
+        Ok(struct_tag_str.to_string())
+    }
+
+    pub fn parse_names(name: &str) -> Result<Vec<String>, MoveRegistryError> {
+        let mut names = vec![];
+        let struct_tag = VERSIONED_NAME_UNBOUND_REG.replace_all(name, |m: &regex::Captures| {
+            // SAFETY: we know that the regex will always have a match on position 0.
+            let name = m.get(0).unwrap().as_str();
+
+            if VersionedName::from_str(name).is_ok() {
+                names.push(name.to_string());
+                "0x0".to_string()
+            } else {
+                name.to_string()
+            }
+        });
+
+        // We attempt to parse the type_tag with these replacements, to make sure there are no other
+        // errors in the type tag (apart from the move names). That protects us from unnecessary
+        // queries to resolve .move names, for a type tag that will be invalid anyway.
+        TypeTag::from_str(&struct_tag)
+            .map_err(|e| MoveRegistryError::InvalidType(format!("bad type: {e}")))?;
+
+        Ok(names)
+    }
+}
+
+/// Helper to replace all occurrences of a regex with a function that returns a string.
+/// Used as a replacement of `regex`.replace_all().
+/// The only difference is that this function returns a Result, so we can handle errors.
+fn replace_all_result(
+    re: &Regex,
+    haystack: &str,
+    replacement: impl Fn(&Captures) -> Result<String, anyhow::Error>,
+) -> Result<String, anyhow::Error> {
+    let mut new = String::with_capacity(haystack.len());
+    let mut last_match = 0;
+    for caps in re.captures_iter(haystack) {
+        // SAFETY: we know that the regex will have a match on position 0.
+        let m = caps.get(0).unwrap();
+        new.push_str(&haystack[last_match..m.start()]);
+        new.push_str(&replacement(&caps)?);
+        last_match = m.end();
+    }
+    new.push_str(&haystack[last_match..]);
+    Ok(new)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{collections::HashMap, str::FromStr};
+
+    use sui_types::base_types::ObjectID;
+
+    use super::NamedType;
+
+    struct DemoData {
+        input_type: String,
+        expected_output: String,
+        expected_names: Vec<String>,
+    }
+
+    #[test]
+    fn parse_and_replace_type_successfully() {
+        let mut demo_data = vec![];
+
+        demo_data.push(DemoData {
+            input_type: "@org/app::type::Type".to_string(),
+            expected_output: format_type("0x0", "::type::Type"),
+            expected_names: vec!["@org/app".to_string()],
+        });
+
+        demo_data.push(DemoData {
+            input_type: "inner@org/app::type::Type".to_string(),
+            expected_output: format_type("0x0", "::type::Type"),
+            expected_names: vec!["inner@org/app".to_string()],
+        });
+
+        demo_data.push(DemoData {
+            input_type: "@org/0xapp::type::Type".to_string(),
+            expected_output: format_type("0x0", "::type::Type"),
+            expected_names: vec!["@org/0xapp".to_string()],
+        });
+
+        demo_data.push(DemoData {
+            input_type: "@org/app::type::Type<u64>".to_string(),
+            expected_output: format_type("0x0", "::type::Type<u64>"),
+            expected_names: vec!["@org/app".to_string()],
+        });
+
+        demo_data.push(DemoData {
+            input_type: "@org/app::type::Type<@org/another-app::type::AnotherType, u64>"
+                .to_string(),
+            expected_output: format!(
+                "{}<{}, u64>",
+                format_type("0x0", "::type::Type"),
+                format_type("0x1", "::type::AnotherType")
+            ),
+            expected_names: vec!["@org/app".to_string(), "@org/another-app".to_string()],
+        });
+
+        demo_data.push(DemoData {
+            input_type: "@org/app::type::Type<@org/another-app::type::AnotherType<@org/even-more-nested::inner::Type>, 0x1::string::String>".to_string(),
+            expected_output: format!("{}<{}<{}>, 0x1::string::String>", format_type("0x0", "::type::Type"), format_type("0x1", "::type::AnotherType"), format_type("0x2", "::inner::Type")),
+            expected_names: vec![
+                "@org/app".to_string(),
+                "@org/another-app".to_string(),
+                "@org/even-more-nested".to_string(),
+            ],
+        });
+
+        for data in demo_data {
+            let names = NamedType::parse_names(&data.input_type).unwrap();
+            assert_eq!(names, data.expected_names);
+
+            let mut mapping = HashMap::new();
+
+            for (index, name) in data.expected_names.iter().enumerate() {
+                mapping.insert(
+                    name.clone(),
+                    ObjectID::from_str(&format!("0x{}", index)).unwrap(),
+                );
+            }
+
+            let replaced = NamedType::replace_names(&data.input_type, &mapping);
+            assert_eq!(replaced.unwrap(), data.expected_output);
+        }
+    }
+
+    #[test]
+    fn parse_and_replace_type_errors() {
+        let types = vec![
+            "@org/--app::type::Type",
+            "@org/app::type::Type<",
+            "@org/app::type::Type<@org/another-app::type::AnotherType, u64",
+            "app@org/v11241--type--::Type",
+            "app-org::type::Type",
+            "app",
+            "@org/app::type::Type<@org/another-app::type@::AnotherType, u64>",
+            "",
+        ];
+
+        // TODO: add snapshot tests for predictable errors.
+        for t in types {
+            assert!(NamedType::parse_names(t).is_err());
+        }
+    }
+
+    fn format_type(address: &str, rest: &str) -> String {
+        format!(
+            "{}{}",
+            ObjectID::from_str(address).unwrap().to_string(),
+            rest
+        )
+    }
+}


### PR DESCRIPTION
Introduces MVR types crate:

1. It takes care of all the parsing for MVR names / types (and the SuiNS equivalents)
2. Exposes the matching errors
3. Enables replacements for type resolution