### PR TITLE
[api] Consistent responses 

### DIFF
--- a/crates/mvr-api/src/handlers/resolution.rs
+++ b/crates/mvr-api/src/handlers/resolution.rs
@@ -40,9 +40,12 @@ impl Resolution {
         let package_id = app_state
             .loader()
             .load_one(ResolutionKey(versioned_name))
-            .await?;
+            .await?
+            .ok_or(ApiError::BadRequest(format!("Name not found: {name}")))?;
 
-        Ok(Json(Response { package_id }))
+        Ok(Json(Response {
+            package_id: Some(package_id),
+        }))
     }
 
     /// Resolve a list of names at once.

--- a/crates/mvr-api/src/handlers/resolution.rs
+++ b/crates/mvr-api/src/handlers/resolution.rs
@@ -25,7 +25,7 @@ pub struct Response {
 
 #[derive(Serialize, Deserialize)]
 pub struct BulkResponse {
-    resolution: HashMap<String, ObjectID>,
+    resolution: HashMap<String, Response>,
 }
 
 pub struct Resolution;
@@ -61,8 +61,15 @@ impl Resolution {
             .load_many(names)
             .await?
             .into_iter()
-            .map(|(name, package_id): (ResolutionKey, ObjectID)| (name.0.to_string(), package_id))
-            .collect::<HashMap<String, ObjectID>>();
+            .map(|(name, package_id): (ResolutionKey, ObjectID)| {
+                (
+                    name.0.to_string(),
+                    Response {
+                        package_id: Some(package_id),
+                    },
+                )
+            })
+            .collect::<HashMap<String, Response>>();
 
         Ok(Json(BulkResponse { resolution }))
     }

--- a/crates/mvr-api/src/handlers/reverse_resolution.rs
+++ b/crates/mvr-api/src/handlers/reverse_resolution.rs
@@ -15,7 +15,7 @@ pub struct BulkRequest {
 }
 #[derive(Serialize, Deserialize)]
 pub struct BulkResponse {
-    resolution: HashMap<ObjectID, String>,
+    resolution: HashMap<ObjectID, Response>,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
@@ -58,7 +58,14 @@ impl ReverseResolution {
         Ok(Json(BulkResponse {
             resolution: results
                 .into_iter()
-                .map(|(key, name)| (key.0, name.to_string()))
+                .map(|(key, name)| {
+                    (
+                        key.0,
+                        Response {
+                            name: Some(name.to_string()),
+                        },
+                    )
+                })
                 .collect(),
         }))
     }

--- a/crates/mvr-api/src/handlers/reverse_resolution.rs
+++ b/crates/mvr-api/src/handlers/reverse_resolution.rs
@@ -36,10 +36,13 @@ impl ReverseResolution {
         let name = app_state
             .loader()
             .load_one(ReverseResolutionKey(package_id))
-            .await?;
+            .await?
+            .ok_or(ApiError::BadRequest(format!(
+                "Name not found for package: {package_id}"
+            )))?;
 
         Ok(Json(Response {
-            name: name.map(|name| name.to_string()),
+            name: Some(name.to_string()),
         }))
     }
 


### PR DESCRIPTION
Make bulk/single API responses a bit more consistent and future proof. We might wanna expose more data in these endpoints in the future.

The idea is:
1. Single endpoints: Throw errors when it doesn't work
2. Bulk endpoints: We optionally return names (generally allowing partial failures (for non existent data only), and delegates handling to clients).