### PR TITLE
[api] metrics & bulk type resolution fix

### DIFF
--- a/crates/mvr-api/src/main.rs
+++ b/crates/mvr-api/src/main.rs
@@ -76,6 +76,10 @@ async fn main() -> Result<(), anyhow::Error> {
         .await
         .unwrap();
 
+    let _handle = tokio::spawn(async move {
+        let _ = metrics.run().await;
+    });
+
     axum::serve(listener, app)
         .with_graceful_shutdown(async move {
             cancel.cancelled().await;


### PR DESCRIPTION
Fixes two things:
1. Run the metrics service
2. Does not fail bulk type resolution calls when names do not exist (preserving the "no failures on bulk endpoints" for nullish values property)