### PR TITLE
[mvr indexer] - separate mainnet and testnet indexer

### DIFF
--- a/crates/mvr-indexer/src/handlers/name_record_handler.rs
+++ b/crates/mvr-indexer/src/handlers/name_record_handler.rs
@@ -2,6 +2,7 @@ use crate::handlers::convert_struct_tag;
 use crate::models::mainnet::mvr_core::app_record::AppRecord;
 use crate::models::mainnet::mvr_core::name::Name as MoveName;
 use crate::models::mainnet::sui::dynamic_field::Field;
+use crate::TESTNET_CHAIN_ID;
 use async_trait::async_trait;
 use diesel::query_dsl::methods::FilterDsl;
 use diesel::upsert::excluded;
@@ -21,18 +22,14 @@ use sui_types::full_checkpoint_content::CheckpointData;
 
 pub struct NameRecordHandler {
     type_: MoveObjectType,
-    testnet_chain_id: String,
 }
 
 impl NameRecordHandler {
-    pub fn new(testnet_chain_id: String) -> Self {
+    pub fn new() -> Self {
         // Indexing dynamic field object Field<[mvr_core]::name::Name, [mvr_core]::app_record::AppRecord>
         let struct_tag = Field::<MoveName, AppRecord>::struct_type();
         let type_ = MoveObjectType::from(convert_struct_tag(struct_tag));
-        NameRecordHandler {
-            type_,
-            testnet_chain_id,
-        }
+        NameRecordHandler { type_ }
     }
 }
 #[async_trait]
@@ -88,7 +85,7 @@ impl Processor for NameRecordHandler {
                                 mainnet_id: app_info
                                     .and_then(|info| Some(info.package_info_id?.to_string())),
                                 testnet_id: networks
-                                    .get(&self.testnet_chain_id)
+                                    .get(TESTNET_CHAIN_ID)
                                     .and_then(|info| Some(info.package_info_id?.to_string())),
                                 metadata: serde_json::to_value(metadata)?,
                             })

--- a/crates/mvr-indexer/src/handlers/package_handler.rs
+++ b/crates/mvr-indexer/src/handlers/package_handler.rs
@@ -1,3 +1,4 @@
+use crate::{MAINNET_CHAIN_ID, TESTNET_CHAIN_ID};
 use chrono::DateTime;
 use diesel_async::RunQueryDsl;
 use itertools::Itertools;
@@ -9,14 +10,14 @@ use sui_pg_db::Connection;
 use sui_types::full_checkpoint_content::CheckpointData;
 use sui_types::object::Data;
 
-pub struct PackageHandler<const MAINNET: bool> {
-    chain_id: String,
-}
+pub struct PackageHandler<const MAINNET: bool>;
 
 impl<const MAINNET: bool> PackageHandler<MAINNET> {
-    pub fn new(chain_id: String) -> Self {
-        Self { chain_id }
-    }
+    const CHAIN_ID: &'static str = if MAINNET {
+        MAINNET_CHAIN_ID
+    } else {
+        TESTNET_CHAIN_ID
+    };
 }
 
 #[async_trait::async_trait]
@@ -89,7 +90,7 @@ impl<const MAINNET: bool> Processor for PackageHandler<MAINNET> {
                                 original_id: p.original_package_id().to_hex_uncompressed(),
                                 package_version: p.version().value() as i64,
                                 move_package: bcs::to_bytes(p)?,
-                                chain_id: self.chain_id.clone(),
+                                chain_id: Self::CHAIN_ID.to_string(),
                                 tx_hash: tx.transaction.digest().base58_encode(),
                                 sender: tx.transaction.sender_address().to_string(),
                                 timestamp,


### PR DESCRIPTION
separated mainnet and testnet indexer, use the `env` flag to choose the environment the indexer will be indexing, can either be `mainnet` or `testnet`.

the environment is defaulted to mainnet if not specified