### PR TITLE
[mvr-api] Introduce "definition" APIs

### DIFF
--- a/crates/mvr-api/src/data/package_resolver.rs
+++ b/crates/mvr-api/src/data/package_resolver.rs
@@ -20,7 +20,7 @@ const STORE: &str = "PostgreSQL";
 pub struct ApiPackageStore(Arc<DataLoader<Reader>>);
 
 #[derive(Copy, Clone, Hash, Eq, PartialEq, Debug)]
-struct PackageKey(AccountAddress);
+pub(crate) struct PackageKey(pub AccountAddress);
 
 impl ApiPackageStore {
     pub fn new(loader: Arc<DataLoader<Reader>>) -> Self {

--- a/crates/mvr-api/src/handlers/mod.rs
+++ b/crates/mvr-api/src/handlers/mod.rs
@@ -9,6 +9,7 @@ use crate::{data::app_state::AppState, errors::ApiError};
 
 pub(crate) mod resolution;
 pub(crate) mod reverse_resolution;
+pub(crate) mod struct_definition;
 pub(crate) mod type_resolution;
 
 pub(crate) async fn health_check(

--- a/crates/mvr-api/src/handlers/struct_definition.rs
+++ b/crates/mvr-api/src/handlers/struct_definition.rs
@@ -1,0 +1,184 @@
+use std::{collections::HashMap, str::FromStr, sync::Arc};
+
+use futures::future::try_join_all;
+
+use axum::{
+    extract::{Path, State},
+    Json,
+};
+use move_core_types::language_storage::StructTag;
+use mvr_types::{name::VersionedName, named_type::NamedType};
+use serde::{Deserialize, Serialize};
+use sui_types::base_types::ObjectID;
+
+use crate::{
+    data::{package_resolver::PackageKey, resolution_loader::ResolutionKey},
+    errors::ApiError,
+    AppState,
+};
+
+#[derive(Serialize, Deserialize, Debug)]
+pub struct BulkRequest {
+    types: Vec<String>,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+pub struct Response {
+    type_tag: Option<String>,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+pub struct BulkResponse {
+    resolution: HashMap<String, Response>,
+}
+
+pub struct StructDefinition;
+
+impl StructDefinition {
+    pub async fn resolve(
+        Path(type_name): Path<String>,
+        State(state): State<Arc<AppState>>,
+    ) -> Result<Json<Response>, ApiError> {
+        verify_input(&type_name)?;
+
+        let tags = bulk_resolve_definitions_impl(state, vec![type_name.clone()]).await?;
+
+        let tag = tags
+            .get(&type_name)
+            .ok_or(ApiError::BadRequest(format!("type not found: {type_name}")))?
+            .clone()
+            .ok_or(ApiError::BadRequest(format!("type not found: {type_name}")))?;
+
+        Ok(Json(Response {
+            type_tag: Some(tag),
+        }))
+    }
+
+    pub async fn bulk_resolve(
+        State(state): State<Arc<AppState>>,
+        Json(payload): Json<BulkRequest>,
+    ) -> Result<Json<BulkResponse>, ApiError> {
+        for type_name in payload.types.iter() {
+            verify_input(type_name)?;
+        }
+
+        let tags = bulk_resolve_definitions_impl(state, payload.types).await?;
+
+        Ok(Json(BulkResponse {
+            resolution: tags
+                .into_iter()
+                .map(|(k, type_tag)| (k, Response { type_tag }))
+                .collect(),
+        }))
+    }
+}
+
+async fn bulk_resolve_definitions_impl(
+    state: Arc<AppState>,
+    types: Vec<String>,
+) -> Result<HashMap<String, Option<String>>, ApiError> {
+    let names = types
+        .iter()
+        .map(|type_name| NamedType::parse_names(type_name))
+        .collect::<Result<Vec<_>, _>>()?
+        .into_iter()
+        .flatten()
+        .map(|name| {
+            let versioned_name = VersionedName::from_str(&name)?;
+            Ok(ResolutionKey(versioned_name))
+        })
+        .collect::<Result<Vec<_>, ApiError>>()?;
+
+    let parsed_name_addresses = state
+        .loader()
+        .load_many(names.clone())
+        .await?
+        .into_iter()
+        .map(|(k, v)| (k.0.to_string(), v))
+        .collect::<HashMap<_, _>>();
+
+    let mapping_ref = Arc::new(parsed_name_addresses);
+
+    let futures = types.into_iter().map(|type_name| {
+        let state = state.clone();
+        let mapping = mapping_ref.clone();
+
+        async move { resolve_definition(type_name, &mapping, &state).await }
+    });
+
+    Ok(try_join_all(futures).await?.into_iter().collect())
+}
+
+/// Given a `type_name`, we try to resolve the definition of that TypeTag.
+/// This is different from the type resolution API, which can resolve any type (primitives, generics, etc.),
+/// but requires the full-type to be valid (cannot do partial generic resolution).
+async fn resolve_definition(
+    type_name: String,
+    mapping: &HashMap<String, ObjectID>,
+    state: &AppState,
+) -> Result<(String, Option<String>), ApiError> {
+    let fixed_type_tag = NamedType::replace_names(&type_name, mapping).ok();
+
+    if fixed_type_tag.is_none() {
+        return Ok((type_name, None));
+    }
+
+    let correct_type_tag = fixed_type_tag.unwrap();
+
+    // For input errors, we throw an error.
+    let parsed_type_tag = StructTag::from_str(&correct_type_tag)
+        .map_err(|e| ApiError::BadRequest(format!("bad type: {e}")))?;
+
+    // For "non-existent packages", we return None, unless we had an unexpected crash,
+    // in which case we return an error.
+    let Some(package) = state
+        .loader()
+        .load_one(PackageKey(parsed_type_tag.address))
+        .await
+        .map_err(|e| ApiError::InternalServerError(format!("package resolver crashed: {e}")))?
+    else {
+        return Ok((type_name, None));
+    };
+
+    // For "non-existent modules", we return None (that's the only error case here).
+    let Some(module) = package.module(parsed_type_tag.module.as_str()).ok() else {
+        return Ok((type_name, None));
+    };
+
+    let Some(data_ref) = module
+        .data_def(parsed_type_tag.name.as_str())
+        .map_err(|e| {
+            ApiError::InternalServerError(format!("Failed to deserialize data def: {e}"))
+        })?
+    else {
+        return Ok((type_name, None));
+    };
+
+    // reformat the type tag with the defining address
+    let res = format!(
+        "{}::{}::{}",
+        data_ref.defining_id.to_canonical_string(true),
+        parsed_type_tag.module.as_str(),
+        parsed_type_tag.name.as_str()
+    );
+
+    Ok((type_name, Some(res)))
+}
+
+fn verify_input(type_name: &str) -> Result<(), ApiError> {
+    if !type_name.contains("::") {
+        return Err(ApiError::BadRequest(format!(
+            "Type `{}` does not contain `::`, so it cannot be a valid struct.",
+            type_name
+        )));
+    }
+
+    if type_name.contains("<") {
+        return Err(ApiError::BadRequest(format!(
+            "Type `{}` contains generic parameters. Use the type resolution APIs instead.",
+            type_name
+        )));
+    }
+
+    Ok(())
+}

--- a/crates/mvr-api/src/metrics/middleware.rs
+++ b/crates/mvr-api/src/metrics/middleware.rs
@@ -19,8 +19,8 @@ pub(crate) async fn track_metrics(
         .extensions()
         .get::<MatchedPath>()
         .map(|p| p.as_str()) // Gets the route name e.g. `/v1/resolution/{*name}`
-        .unwrap_or("UNKNOWN")
-        .to_string(); // defaults to UNKNOWN
+        .unwrap_or("/UNSUPPORTED")
+        .to_string();
 
     // Add the `network` as part of the route. That way both API instances can report
     // metrics for the same route name.

--- a/crates/mvr-api/src/route.rs
+++ b/crates/mvr-api/src/route.rs
@@ -7,7 +7,7 @@ use crate::{
     data::app_state::AppState,
     handlers::{
         health_check, resolution::Resolution, reverse_resolution::ReverseResolution,
-        type_resolution::TypeResolution,
+        struct_definition::StructDefinition, type_resolution::TypeResolution,
     },
     metrics::middleware::track_metrics,
 };
@@ -33,6 +33,14 @@ pub fn create_router(app: Arc<AppState>) -> Router {
         .route(
             "/type-resolution/{*type_name}",
             get(TypeResolution::resolve),
+        )
+        .route(
+            "/struct-definition/bulk",
+            post(StructDefinition::bulk_resolve),
+        )
+        .route(
+            "/struct-definition/{*type_name}",
+            get(StructDefinition::resolve),
         );
 
     Router::new()

--- a/crates/mvr-indexer/src/main.rs
+++ b/crates/mvr-indexer/src/main.rs
@@ -4,6 +4,7 @@ use crate::handlers::package_handler::PackageHandler;
 use crate::handlers::package_info_handler::PackageInfoHandler;
 use anyhow::Context;
 use clap::Parser;
+use mvr_schema::MIGRATIONS;
 use prometheus::Registry;
 use std::collections::HashMap;
 use std::fmt::{Display, Formatter};
@@ -15,7 +16,6 @@ use sui_indexer_alt_metrics::{MetricsArgs, MetricsService};
 use sui_pg_db::DbArgs;
 use tokio_util::sync::CancellationToken;
 use url::Url;
-use mvr_schema::MIGRATIONS;
 
 pub(crate) mod handlers;
 
@@ -57,7 +57,7 @@ async fn main() -> Result<(), anyhow::Error> {
         Some("mvr".into()),
         Some(HashMap::from([("mvr_env".to_string(), env.to_string())])),
     )
-        .context("Failed to create Prometheus registry.")?;
+    .context("Failed to create Prometheus registry.")?;
     let metrics = MetricsService::new(
         MetricsArgs { metrics_address },
         registry,
@@ -76,7 +76,7 @@ async fn main() -> Result<(), anyhow::Error> {
         metrics.registry(),
         cancel.clone(),
     )
-        .await?;
+    .await?;
 
     match env {
         MvrEnv::Mainnet => create_mainnet_pipelines(&mut indexer).await?,
@@ -155,7 +155,7 @@ impl Display for MvrEnv {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         match self {
             MvrEnv::Mainnet => write!(f, "mainnet"),
-            MvrEnv::Testnet => write!(f, "testnet")
+            MvrEnv::Testnet => write!(f, "testnet"),
         }
     }
 }

--- a/crates/mvr-types/Cargo.toml
+++ b/crates/mvr-types/Cargo.toml
@@ -4,9 +4,9 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-sui-types = { git = "https://github.com/MystenLabs/sui.git", rev = "e919e84"}
 serde = { workspace = true, features = ["derive"] }
 anyhow.workspace = true
 thiserror.workspace = true
 once_cell.workspace = true
 regex = "1.11.1"
+sui-types.workspace = true


### PR DESCRIPTION
Introduces the "definition" APIs which allow named struct definitions discovery, without the need for supplying a fully-qualified type (w/ generics).

First usage of this will be for our static resolution plugin.