### PR TITLE
[api] Query package dependencies

### DIFF
--- a/crates/mvr-api/src/data/mod.rs
+++ b/crates/mvr-api/src/data/mod.rs
@@ -5,6 +5,7 @@ use crate::errors::ApiError;
 
 pub(crate) mod app_state;
 pub(crate) mod package_by_name_loader;
+pub(crate) mod package_dependencies;
 pub(crate) mod package_resolver;
 pub(crate) mod reader;
 pub(crate) mod resolution_loader;

--- a/crates/mvr-api/src/data/package_dependencies.rs
+++ b/crates/mvr-api/src/data/package_dependencies.rs
@@ -1,0 +1,76 @@
+use std::{collections::HashMap, str::FromStr};
+
+use async_graphql::dataloader::Loader;
+use diesel::{ExpressionMethods, QueryDsl};
+use mvr_schema::schema::package_dependencies;
+use serde::{Deserialize, Serialize};
+use sui_sdk_types::ObjectId;
+
+use crate::errors::ApiError;
+
+use super::reader::Reader;
+
+// This is a key to load all dependencies for a package.
+// Since there are system limits, we do not paginate this endpoint.
+#[derive(Clone, Eq, PartialEq, Hash, Debug)]
+pub struct PackageDependenciesKey(pub ObjectId);
+
+#[derive(Serialize, Deserialize, Clone)]
+pub struct PackageDependencies {
+    pub dependencies: Vec<ObjectId>,
+}
+
+impl Default for PackageDependencies {
+    fn default() -> Self {
+        Self {
+            dependencies: Vec::new(),
+        }
+    }
+}
+
+#[async_trait::async_trait]
+impl Loader<PackageDependenciesKey> for Reader {
+    type Value = PackageDependencies;
+    type Error = ApiError;
+
+    async fn load(
+        &self,
+        keys: &[PackageDependenciesKey],
+    ) -> Result<HashMap<PackageDependenciesKey, Self::Value>, Self::Error> {
+        if keys.is_empty() {
+            return Ok(HashMap::new());
+        }
+
+        let mut connection = self.connect().await?;
+
+        let package_ids = keys.iter().map(|k| k.0.to_string()).collect::<Vec<_>>();
+
+        let query = package_dependencies::table
+            .select((
+                package_dependencies::package_id,
+                package_dependencies::dependency_package_id,
+            ))
+            .filter(package_dependencies::package_id.eq_any(package_ids));
+
+        let result: Vec<(String, String)> = connection.results(query).await?;
+
+        let dependencies = result.iter().fold(
+            HashMap::new(),
+            |mut acc, (package_id, dependency_package_id)| {
+                acc.entry(PackageDependenciesKey(
+                    // SAFETY: We know that the package_id is a valid ObjectId
+                    ObjectId::from_str(package_id).unwrap(),
+                ))
+                .or_insert_with(|| PackageDependencies {
+                    dependencies: Vec::new(),
+                })
+                // SAFETY: We know that the dependency_package_id is a valid ObjectId
+                .dependencies
+                .push(ObjectId::from_str(&dependency_package_id).unwrap());
+                acc
+            },
+        );
+
+        Ok(dependencies)
+    }
+}

--- a/crates/mvr-api/src/handlers/mod.rs
+++ b/crates/mvr-api/src/handlers/mod.rs
@@ -14,6 +14,7 @@ use crate::{
 const BATCH_SIZE_DEFAULT: usize = 50;
 
 pub(crate) mod names;
+pub(crate) mod package_address;
 pub(crate) mod resolution;
 pub(crate) mod reverse_resolution;
 pub(crate) mod struct_definition;

--- a/crates/mvr-api/src/handlers/package_address.rs
+++ b/crates/mvr-api/src/handlers/package_address.rs
@@ -1,0 +1,37 @@
+use std::{str::FromStr, sync::Arc};
+
+use axum::{
+    extract::{Path, State},
+    Json,
+};
+use sui_sdk_types::ObjectId;
+
+use crate::{
+    data::{
+        app_state::AppState,
+        package_dependencies::{PackageDependencies, PackageDependenciesKey},
+    },
+    errors::ApiError,
+};
+
+pub struct PackageAddress;
+
+impl PackageAddress {
+    /// Returns a list of all dependencies for a package address.
+    pub async fn dependencies(
+        Path(package_address): Path<String>,
+        State(app_state): State<Arc<AppState>>,
+    ) -> Result<Json<PackageDependencies>, ApiError> {
+        let object_id = ObjectId::from_str(&package_address)
+            .map_err(|e| ApiError::BadRequest(format!("Invalid package address: {}", e)))?;
+
+        let dependencies = app_state
+            .cached_loader()
+            .load_one(PackageDependenciesKey(object_id))
+            .await?;
+
+        let dependencies = dependencies.unwrap_or_default();
+
+        Ok(Json(dependencies))
+    }
+}

--- a/crates/mvr-api/src/route.rs
+++ b/crates/mvr-api/src/route.rs
@@ -6,8 +6,9 @@ use std::sync::Arc;
 use crate::{
     data::app_state::AppState,
     handlers::{
-        health_check, names::Names, resolution::Resolution, reverse_resolution::ReverseResolution,
-        struct_definition::StructDefinition, type_resolution::TypeResolution,
+        health_check, names::Names, package_address::PackageAddress, resolution::Resolution,
+        reverse_resolution::ReverseResolution, struct_definition::StructDefinition,
+        type_resolution::TypeResolution,
     },
     metrics::middleware::track_metrics,
 };
@@ -48,7 +49,11 @@ pub fn create_router(app: Arc<AppState>) -> Router {
             // Queries all names (paginated & can supply search query)
             get(Names::search_names),
         )
-        .route("/names/{*name}", get(Names::get_by_name));
+        .route("/names/{*name}", get(Names::get_by_name))
+        .route(
+            "/package-address/{package_address}/dependencies",
+            get(PackageAddress::dependencies),
+        );
 
     Router::new()
         .route("/health", get(health_check))


### PR DESCRIPTION
- Adds querying for package dependencies (non-paginated, as we're protected from system limits)
- Adds a "cached loader" for non time-critical data and immutable data (E.g. analytics per date, dependencies)