### PR TITLE
[api] Allow querying package dependents

### DIFF
--- a/crates/mvr-api/src/data/mod.rs
+++ b/crates/mvr-api/src/data/mod.rs
@@ -6,6 +6,7 @@ use crate::errors::ApiError;
 pub(crate) mod app_state;
 pub(crate) mod package_by_name_loader;
 pub(crate) mod package_dependencies;
+pub(crate) mod package_dependents;
 pub(crate) mod package_resolver;
 pub(crate) mod reader;
 pub(crate) mod resolution_loader;

--- a/crates/mvr-api/src/data/package_dependents.rs
+++ b/crates/mvr-api/src/data/package_dependents.rs
@@ -1,0 +1,117 @@
+use std::collections::HashMap;
+
+use async_graphql::dataloader::Loader;
+use chrono::NaiveDate;
+use diesel::{
+    prelude::QueryableByName,
+    sql_types::{BigInt, Integer, Text},
+};
+use futures::future::try_join_all;
+use serde::{Deserialize, Serialize};
+use sui_sdk_types::ObjectId;
+
+use crate::{errors::ApiError, utils::pagination::PaginationLimit};
+
+use super::reader::Reader;
+
+#[derive(Serialize, Deserialize, Debug, Default, Clone, Eq, PartialEq, Hash)]
+pub struct PackageDependentsCursor {
+    pub package_id: Option<ObjectId>,
+    pub aggregated_total_calls: Option<i64>,
+}
+
+#[derive(Clone, Eq, PartialEq, Hash, Debug)]
+pub struct PackageDependentsKey(
+    pub ObjectId,
+    pub PackageDependentsCursor,
+    pub PaginationLimit,
+    pub NaiveDate,
+);
+
+#[derive(Serialize, Deserialize, Clone, QueryableByName)]
+pub struct PackageDependent {
+    #[diesel(sql_type = diesel::sql_types::Text)]
+    pub package_id: String,
+    #[diesel(sql_type = diesel::sql_types::BigInt)]
+    pub aggregated_total_calls: i64,
+    #[diesel(sql_type = diesel::sql_types::BigInt)]
+    pub aggregated_direct_calls: i64,
+    #[diesel(sql_type = diesel::sql_types::BigInt)]
+    pub aggregated_propagated_calls: i64,
+}
+
+#[async_trait::async_trait]
+impl Loader<PackageDependentsKey> for Reader {
+    type Value = Vec<PackageDependent>;
+    type Error = ApiError;
+
+    async fn load(
+        &self,
+        keys: &[PackageDependentsKey],
+    ) -> Result<HashMap<PackageDependentsKey, Self::Value>, Self::Error> {
+        let requests = keys
+            .iter()
+            .map(|key| get_package_dependents(self, key.clone()));
+
+        // In this particular scenario, we use `try_join_all` to parallelize our db queries,
+        // because there is no easy way to parallelize the db queries in the SQL layer,
+        // because of our cursor-based pagination.
+        let result = try_join_all(requests).await?.iter().fold(
+            HashMap::new(),
+            |mut acc, (key, dependents)| {
+                acc.insert(key.clone(), dependents.clone());
+                acc
+            },
+        );
+
+        Ok(result)
+    }
+}
+
+async fn get_package_dependents(
+    reader: &Reader,
+    key: PackageDependentsKey,
+) -> Result<(PackageDependentsKey, Vec<PackageDependent>), ApiError> {
+    let package_id = &key.0;
+
+    let mut connection = reader.connect().await?;
+
+    let sql_query = diesel::sql_query(DEPENDENTS_QUERY)
+        .bind::<Text, _>(package_id.to_string())
+        .bind::<Text, _>(
+            key.1
+                .package_id
+                .map(|id| id.to_string())
+                .unwrap_or_default(),
+        )
+        .bind::<BigInt, _>(key.1.aggregated_total_calls.unwrap_or(i64::MAX))
+        .bind::<Integer, _>(key.2.query_limit() as i32);
+
+    let result: Vec<PackageDependent> = connection.results(sql_query).await?;
+
+    Ok((key, result))
+}
+
+const DEPENDENTS_QUERY: &str = "WITH dependents AS (
+    SELECT pd.package_id 
+    FROM package_dependencies pd 
+    WHERE pd.dependency_package_id = $1), 
+latest_activity AS (
+    SELECT DISTINCT ON (pa.package_id)
+        pa.package_id, 
+        pa.aggregated_total_calls, 
+        pa.aggregated_direct_calls, 
+        pa.aggregated_propagated_calls
+    FROM package_analytics pa
+    JOIN dependents d ON pa.package_id = d.package_id
+    ORDER BY pa.package_id, pa.call_date DESC)
+SELECT 
+    d.package_id as package_id,
+    COALESCE(la.aggregated_direct_calls, 0) AS aggregated_direct_calls,
+    COALESCE(la.aggregated_propagated_calls, 0) AS aggregated_propagated_calls,
+	COALESCE(la.aggregated_total_calls, 0) AS aggregated_total_calls
+FROM dependents d
+LEFT JOIN latest_activity la ON d.package_id = la.package_id
+WHERE (aggregated_total_calls < $3) OR (aggregated_total_calls = $3 AND d.package_id > $2)
+ORDER BY aggregated_total_calls DESC, d.package_id ASC
+LIMIT $4";

--- a/crates/mvr-api/src/data/package_dependents.rs
+++ b/crates/mvr-api/src/data/package_dependents.rs
@@ -56,15 +56,7 @@ impl Loader<PackageDependentsKey> for Reader {
         // In this particular scenario, we use `try_join_all` to parallelize our db queries,
         // because there is no easy way to parallelize the db queries in the SQL layer,
         // because of our cursor-based pagination.
-        let result = try_join_all(requests).await?.iter().fold(
-            HashMap::new(),
-            |mut acc, (key, dependents)| {
-                acc.insert(key.clone(), dependents.clone());
-                acc
-            },
-        );
-
-        Ok(result)
+        Ok(try_join_all(requests).await?.into_iter().collect())
     }
 }
 

--- a/crates/mvr-api/src/handlers/package_address.rs
+++ b/crates/mvr-api/src/handlers/package_address.rs
@@ -1,18 +1,28 @@
 use std::{str::FromStr, sync::Arc};
 
 use axum::{
-    extract::{Path, State},
+    extract::{Path, Query, State},
     Json,
 };
+use chrono::Local;
+use serde::{Deserialize, Serialize};
 use sui_sdk_types::ObjectId;
 
 use crate::{
     data::{
         app_state::AppState,
         package_dependencies::{PackageDependencies, PackageDependenciesKey},
+        package_dependents::{PackageDependent, PackageDependentsCursor, PackageDependentsKey},
     },
     errors::ApiError,
+    utils::pagination::{format_paginated_response, Cursor, PaginatedResponse, PaginationLimit},
 };
+
+#[derive(Serialize, Deserialize, Debug)]
+pub struct DependentsQueryParams {
+    pub cursor: Option<String>,
+    pub limit: Option<u32>,
+}
 
 pub struct PackageAddress;
 
@@ -30,8 +40,42 @@ impl PackageAddress {
             .load_one(PackageDependenciesKey(object_id))
             .await?;
 
-        let dependencies = dependencies.unwrap_or_default();
+        Ok(Json(dependencies.unwrap_or_default()))
+    }
 
-        Ok(Json(dependencies))
+    /// Returns a list of all dependents for a package address, ordered by the number of total calls to that package.
+    /// We are caching the stats on a daily basis, and we do not really care about minor changes within a single day,
+    /// on the stats. The only reason we save the Date in the Key, is to re-cache the stats each new day.
+    ///
+    /// Since our cache is LRU, old entries will eventually be removed, and we will re-fetch the stats from the DB.
+    pub async fn dependents(
+        Path(package_address): Path<String>,
+        Query(params): Query<DependentsQueryParams>,
+        State(app_state): State<Arc<AppState>>,
+    ) -> Result<Json<PaginatedResponse<PackageDependent>>, ApiError> {
+        let object_id = ObjectId::from_str(&package_address)
+            .map_err(|e| ApiError::BadRequest(format!("Invalid package address: {}", e)))?;
+
+        let limit = PaginationLimit::new(params.limit)?;
+        let cursor = Cursor::decode_or_default::<PackageDependentsCursor>(&params.cursor)?;
+
+        let dependents = app_state
+            .cached_loader()
+            .load_one(PackageDependentsKey(
+                object_id,
+                cursor,
+                limit.clone(),
+                Local::now().date_naive(),
+            ))
+            .await?;
+
+        Ok(Json(format_paginated_response(
+            dependents.unwrap_or_default(),
+            limit.get(),
+            |item| PackageDependentsCursor {
+                package_id: Some(ObjectId::from_str(&item.package_id).unwrap()),
+                aggregated_total_calls: Some(item.aggregated_total_calls),
+            },
+        )))
     }
 }

--- a/crates/mvr-api/src/lib.rs
+++ b/crates/mvr-api/src/lib.rs
@@ -13,9 +13,10 @@ use axum::http::{
 };
 use clap::ValueEnum;
 use data::app_state::AppState;
+use mvr_schema::MIGRATIONS;
 use prometheus::Registry;
 use sui_indexer_alt_metrics::{MetricsArgs, MetricsService};
-use sui_pg_db::DbArgs;
+use sui_pg_db::{Db, DbArgs};
 use tokio_util::sync::CancellationToken;
 use tower_http::cors::{Any, CorsLayer};
 use url::Url;
@@ -76,6 +77,12 @@ pub async fn run_server(
 pub enum Network {
     Mainnet,
     Testnet,
+}
+
+pub async fn run_migrations(url: Url, args: DbArgs) -> Result<(), anyhow::Error> {
+    let db = Db::for_write(url, args).await?;
+    db.run_migrations(MIGRATIONS).await?;
+    Ok(())
 }
 
 impl std::fmt::Display for Network {

--- a/crates/mvr-api/src/main.rs
+++ b/crates/mvr-api/src/main.rs
@@ -4,7 +4,7 @@
 use std::net::SocketAddr;
 
 use clap::Parser;
-use mvr_api::{run_server, Network};
+use mvr_api::{run_migrations, run_server, Network};
 use sui_pg_db::DbArgs;
 use tokio_util::sync::CancellationToken;
 use url::Url;
@@ -41,6 +41,8 @@ async fn main() -> Result<(), anyhow::Error> {
         metrics_address,
         database_url,
     } = Args::parse();
+
+    run_migrations(database_url.clone(), db_args.clone()).await?;
 
     let cancel = CancellationToken::new();
 

--- a/crates/mvr-api/src/route.rs
+++ b/crates/mvr-api/src/route.rs
@@ -53,6 +53,10 @@ pub fn create_router(app: Arc<AppState>) -> Router {
         .route(
             "/package-address/{package_address}/dependencies",
             get(PackageAddress::dependencies),
+        )
+        .route(
+            "/package-address/{package_address}/dependents",
+            get(PackageAddress::dependents),
         );
 
     Router::new()

--- a/crates/mvr-api/src/utils/pagination.rs
+++ b/crates/mvr-api/src/utils/pagination.rs
@@ -6,7 +6,7 @@ use crate::errors::ApiError;
 pub(crate) const DEFAULT_PAGE_LIMIT: u32 = 20;
 pub(crate) const MAX_PAGE_LIMIT: u32 = 50;
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, Eq, PartialEq, Hash)]
 pub struct PaginationLimit(u32);
 
 impl Default for PaginationLimit {

--- a/crates/mvr-schema/migrations/2025-02-10-104023_mvr/up.sql
+++ b/crates/mvr-schema/migrations/2025-02-10-104023_mvr/up.sql
@@ -1,4 +1,4 @@
-CREATE TABLE packages
+CREATE TABLE IF NOT EXISTS packages
 (
     package_id      VARCHAR   NOT NULL,
     original_id     VARCHAR   NOT NULL,
@@ -12,9 +12,9 @@ CREATE TABLE packages
     CONSTRAINT packages_unique_package_id UNIQUE (package_id, chain_id)
 );
 -- Index to optimize package filtering | Bulk resolution | Tested on Million records operations
-CREATE INDEX idx_packages_original_id_version_filtering ON packages(original_id, package_version DESC);
+CREATE INDEX IF NOT EXISTS idx_packages_original_id_version_filtering ON packages(original_id, package_version DESC);
 
-CREATE TABLE package_dependencies
+CREATE TABLE IF NOT EXISTS package_dependencies
 (
     package_id            VARCHAR NOT NULL,
     dependency_package_id VARCHAR NOT NULL,
@@ -23,7 +23,7 @@ CREATE TABLE package_dependencies
 );
 
 
-CREATE TABLE name_records
+CREATE TABLE IF NOT EXISTS name_records
 (
     name           VARCHAR NOT NULL PRIMARY KEY,
     object_version BIGINT  NOT NULL,
@@ -32,10 +32,10 @@ CREATE TABLE name_records
     metadata       JSONB   NOT NULL
 );
 
-CREATE INDEX idx_name_records_mainnet_id ON name_records (mainnet_id);
-CREATE INDEX idx_name_records_testnet_id ON name_records (testnet_id);
+CREATE INDEX IF NOT EXISTS idx_name_records_mainnet_id ON name_records (mainnet_id);
+CREATE INDEX IF NOT EXISTS idx_name_records_testnet_id ON name_records (testnet_id);
 
-CREATE TABLE package_infos
+CREATE TABLE IF NOT EXISTS package_infos
 (
     id             VARCHAR NOT NULL PRIMARY KEY,
     object_version BIGINT  NOT NULL,
@@ -46,9 +46,9 @@ CREATE TABLE package_infos
     metadata       JSONB   NOT NULL
 );
 
-CREATE INDEX idx_package_infos_package_id ON package_infos (package_id);
+CREATE INDEX IF NOT EXISTS idx_package_infos_package_id ON package_infos (package_id);
 
-CREATE TABLE git_infos
+CREATE TABLE IF NOT EXISTS git_infos
 (
     table_id       VARCHAR NOT NULL,
     object_version BIGINT  NOT NULL,
@@ -60,4 +60,4 @@ CREATE TABLE git_infos
     PRIMARY KEY (table_id, version)
 );
 
-CREATE INDEX idx_git_infos_table_id ON git_infos (table_id);
+CREATE INDEX IF NOT EXISTS idx_git_infos_table_id ON git_infos (table_id);

--- a/crates/mvr-schema/migrations/2025-04-15-124613_analytics_and_indexes/down.sql
+++ b/crates/mvr-schema/migrations/2025-04-15-124613_analytics_and_indexes/down.sql
@@ -1,0 +1,5 @@
+DROP INDEX IF EXISTS package_analytics_call_date_package_id_idx;
+DROP INDEX IF EXISTS package_analytics_package_id_idx;
+DROP INDEX IF EXISTS idx_package_dependencies_package_id;
+DROP INDEX IF EXISTS idx_package_dependencies_dependency_package_id;
+DROP TABLE IF EXISTS package_analytics;

--- a/crates/mvr-schema/migrations/2025-04-15-124613_analytics_and_indexes/up.sql
+++ b/crates/mvr-schema/migrations/2025-04-15-124613_analytics_and_indexes/up.sql
@@ -1,0 +1,18 @@
+-- Package analytics table
+CREATE TABLE IF NOT EXISTS package_analytics (
+    call_date DATE NOT NULL,
+    package_id TEXT NOT NULL,
+    direct_calls BIGINT NOT NULL,
+    aggregated_direct_calls BIGINT NOT NULL,
+    propagated_calls BIGINT NOT NULL,
+    aggregated_propagated_calls BIGINT NOT NULL,
+    total_calls BIGINT NOT NULL,
+    aggregated_total_calls BIGINT NOT NULL,
+    CONSTRAINT package_analytics_pkey PRIMARY KEY (call_date, package_id)
+);
+
+-- Package analytics indexes
+CREATE INDEX IF NOT EXISTS package_analytics_package_id_idx ON package_analytics (package_id);
+-- Package dependencies indexes
+CREATE INDEX IF NOT EXISTS idx_package_dependencies_package_id ON package_dependencies (package_id);
+CREATE INDEX IF NOT EXISTS idx_package_dependencies_dependency_package_id ON package_dependencies (dependency_package_id);

--- a/crates/mvr-schema/src/schema.rs
+++ b/crates/mvr-schema/src/schema.rs
@@ -55,6 +55,19 @@ diesel::table! {
     }
 }
 
+diesel::table! {
+    package_analytics (call_date, package_id) {
+        call_date -> Date,
+        package_id -> Varchar,
+        direct_calls -> BigInt,
+        aggregated_direct_calls -> BigInt,
+        propagated_calls -> BigInt,
+        aggregated_propagated_calls -> BigInt,
+        total_calls -> BigInt,
+        aggregated_total_calls -> BigInt,
+    }
+}
+
 diesel::allow_tables_to_appear_in_same_query!(
     git_infos,
     name_records,


### PR DESCRIPTION
- Allows querying (paginated) package dependents.
- We use a date-based caching logic for paginated queries, to serve hot FE queries from cache (our analytics change daily, so the old date elements would just be pushed off the LRU cache)
- Triggers migration runs from the API too (now it was just the indexer!)