### PR TITLE
[api] Allow narrowing down search to linked names

### DIFF
--- a/crates/mvr-api/src/handlers/names.rs
+++ b/crates/mvr-api/src/handlers/names.rs
@@ -23,6 +23,8 @@ use crate::{
     utils::pagination::{format_paginated_response, Cursor, PaginatedResponse, PaginationLimit},
 };
 
+use super::validate_search_query;
+
 #[derive(Serialize, Deserialize)]
 pub struct PackageByNameResponse {
     #[serde(flatten)]
@@ -98,6 +100,8 @@ impl Names {
         State(app_state): State<Arc<AppState>>,
     ) -> Result<Json<PaginatedResponse<NameSearchResponse>>, ApiError> {
         let search = params.search.unwrap_or_default();
+        validate_search_query(&search)?;
+
         let limit = PaginationLimit::new(params.limit)?;
         let cursor = Cursor::decode_or_default::<NameCursor>(&params.cursor)?;
 

--- a/crates/mvr-types/src/name_service.rs
+++ b/crates/mvr-types/src/name_service.rs
@@ -8,7 +8,7 @@ use std::str::FromStr;
 use crate::errors::NameServiceError;
 
 const DEFAULT_TLD: &str = "sui";
-const ACCEPTED_SEPARATORS: [char; 2] = ['.', '*'];
+const ACCEPTED_SEPARATORS: [char; 1] = ['.'];
 const SUI_NEW_FORMAT_SEPARATOR: char = '@';
 
 /// Two different view options for a domain.


### PR DESCRIPTION
Allows searching only linked names (Names that are either available on mainnet, or testnet).