### PR TITLE
[api] Fix dependents query to prevent skipping packages without any calls

### DIFF
--- a/crates/mvr-api/src/data/package_dependents.rs
+++ b/crates/mvr-api/src/data/package_dependents.rs
@@ -104,6 +104,7 @@ SELECT
 	COALESCE(la.aggregated_total_calls, 0) AS aggregated_total_calls
 FROM dependents d
 LEFT JOIN latest_activity la ON d.package_id = la.package_id
-WHERE (aggregated_total_calls < $3) OR (aggregated_total_calls = $3 AND d.package_id > $2)
+WHERE (COALESCE(la.aggregated_total_calls, 0) < $3)
+   OR (COALESCE(la.aggregated_total_calls, 0) = $3 AND d.package_id > $2)
 ORDER BY aggregated_total_calls DESC, d.package_id ASC
 LIMIT $4";


### PR DESCRIPTION
Right now, the filter (on the where statement) was wrong, because it would only work against packages whose join with analytics produced results.