### PR TITLE
[attestations 2] Security-tab attestation UI (issued tab, audit signals)

### DIFF
--- a/app/src/app/attestors/page.tsx
+++ b/app/src/app/attestors/page.tsx
@@ -1,0 +1,78 @@
+"use client";
+
+import { PlainPageLayout } from "@/components/layouts/PlainPageLayout";
+import { Text } from "@/components/ui/Text";
+import { AttesterAvatar } from "@/components/single-package/SinglePackageTrustSignals";
+import { allTrustedAttestors, type TrustedAttestor } from "@/lib/attestations";
+import { beautifySuiAddress } from "@/lib/utils";
+
+export default function TrustedAttestorsPage() {
+  const attestors = allTrustedAttestors();
+
+  return (
+    <PlainPageLayout>
+      <div className="flex flex-col gap-lg py-lg">
+        <div className="flex flex-col gap-xs">
+          <Text kind="heading" size="heading-regular">
+            Trusted attestors
+          </Text>
+          <Text
+            as="p"
+            kind="paragraph"
+            size="paragraph-small"
+            className="max-w-2xl text-content-secondary"
+          >
+            Attestations are surfaced only from this curated set of attesters.
+            Trust is a consumer-side choice — these are the packages MVR
+            recognizes as authoritative sources of audits and vulnerability
+            disclosures.
+          </Text>
+        </div>
+
+        {attestors.length === 0 ? (
+          <Text as="p" kind="paragraph" size="paragraph-small">
+            No trusted attestors are configured.
+          </Text>
+        ) : (
+          <div className="flex flex-col gap-sm">
+            {attestors.map((a) => (
+              <AttestorCard key={a.originalId} attestor={a} />
+            ))}
+          </div>
+        )}
+      </div>
+    </PlainPageLayout>
+  );
+}
+
+function AttestorCard({ attestor }: { attestor: TrustedAttestor }) {
+  return (
+    <div className="flex items-center gap-md rounded-md bg-bg-secondary p-md">
+      <AttesterAvatar attestor={attestor} size="lg" />
+      <div className="flex flex-col gap-2xs">
+        <Text kind="label" size="label-regular">
+          {attestor.name}
+        </Text>
+        {attestor.mvrName ? (
+          <a
+            href={`/package/${attestor.mvrName}`}
+            className="text-content-accent underline w-fit"
+          >
+            <Text kind="paragraph" size="paragraph-xs">
+              {attestor.mvrName}
+            </Text>
+          </a>
+        ) : (
+          <Text
+            as="p"
+            kind="paragraph"
+            size="paragraph-xs"
+            className="font-mono opacity-60"
+          >
+            {beautifySuiAddress(attestor.originalId)}
+          </Text>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/app/src/components/single-package/SinglePackage.tsx
+++ b/app/src/components/single-package/SinglePackage.tsx
@@ -12,6 +12,14 @@ import { ReadMeRenderer } from "./ReadMeRenderer";
 import { SinglePackageDependencies } from "./SinglePackageDependencies";
 import { SinglePackageDependents } from "./SinglePackageDependents";
 import { SinglePackageVersions } from "./SinglePackageVersions";
+import {
+  SinglePackageTrustSignals,
+  TrustSignalCount,
+} from "./SinglePackageTrustSignals";
+import {
+  SinglePackageIssued,
+  IssuedCount,
+} from "./SinglePackageIssued";
 import { DependenciesIconSelected } from "@/icons/single-package/DependenciesIcon";
 import { DependendsIconSelected } from "@/icons/single-package/DependendsIcon";
 import { DependenciesIconUnselected } from "@/icons/single-package/DependenciesIcon";
@@ -23,6 +31,25 @@ import { ReadMeIconUnselected } from "@/icons/single-package/ReadMeIcon";
 import { SinglePackageTab } from "@/utils/types";
 import { AnalyticsIconUnselected } from "@/icons/single-package/AnalyticsIcon";
 import { AnalyticsIconSelected } from "@/icons/single-package/AnalyticsIcon";
+import { attestationConfig, isConfiguredAttestor } from "@/lib/attestations";
+import { useTrustedAttestors } from "@/hooks/useTrustedAttestors";
+
+// Simple shield-check glyph for the Trust Signals tab; reused for both states.
+const TrustSignalsIcon = () => (
+  <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+    <path d="M12 3l7 3v5c0 4.5-3 7.5-7 9-4-1.5-7-4.5-7-9V6l7-3z" />
+    <path d="M9 12l2 2 4-4" />
+  </svg>
+);
+
+// Upload/outbox glyph for the Issued tab (attestations this package emits).
+const IssuedIcon = () => (
+  <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+    <path d="M4 17v2a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2v-2" />
+    <path d="M12 15V3" />
+    <path d="M7 8l5-5 5 5" />
+  </svg>
+);
 
 export const Tabs: SinglePackageTab[] = [
   {
@@ -69,6 +96,28 @@ export const Tabs: SinglePackageTab[] = [
     component: (name: ResolvedName) => <SinglePackageDependents name={name} />,
   },
   {
+    key: "trust-signals",
+    title: "Security",
+    selectedIcon: <TrustSignalsIcon />,
+    unselectedIcon: <TrustSignalsIcon />,
+    label: (address: string, network: "mainnet" | "testnet") => (
+      <TrustSignalCount address={address} network={network} />
+    ),
+    component: (name: ResolvedName) => <SinglePackageTrustSignals name={name} />,
+  },
+  {
+    key: "issued",
+    title: "Attestations",
+    selectedIcon: <IssuedIcon />,
+    unselectedIcon: <IssuedIcon />,
+    label: (
+      _address: string,
+      network: "mainnet" | "testnet",
+      name?: ResolvedName,
+    ) => (name ? <IssuedCount name={name} network={network} /> : null),
+    component: (name: ResolvedName) => <SinglePackageIssued name={name} />,
+  },
+  {
     key: "analytics",
     title: "Analytics",
     selectedIcon: <AnalyticsIconSelected />,
@@ -89,7 +138,24 @@ export function SinglePackage({
   const router = useRouter();
   const searchParams = useSearchParams();
 
-  const [activeTab, setActiveTab] = useState(Tabs[0]!.key);
+  // The "Issued" tab is in the nav only for configured attesters (a free
+  // in-memory check), but it stays reachable by URL (?tab=issued) for any
+  // package — the panel shows a not-trusted warning. So nav visibility
+  // (navTabs) and URL-selectability (the full Tabs list) differ.
+  //
+  // The attestation tabs (trust-signals, issued) render nothing on a network with
+  // no trust config, so drop them from the nav there rather than show empty tabs.
+  const cfg = attestationConfig(network);
+  const { attestors } = useTrustedAttestors(network);
+  const attestationKeys = ["trust-signals", "issued"];
+  const navTabs = Tabs.filter((t) => {
+    if (!cfg && attestationKeys.includes(t.key)) return false;
+    if (t.key === "issued" && !isConfiguredAttestor(attestors, name.package_address))
+      return false;
+    return true;
+  });
+
+  const [activeTab, setActiveTab] = useState(navTabs[0]!.key);
 
   useEffect(() => {
     const tab = searchParams.get("tab");
@@ -112,7 +178,7 @@ export function SinglePackage({
       <div className="container">
         <div className="grid grid-cols-1 gap-2xl lg:grid-cols-24">
           <SinglePackageTabs
-            tabs={Tabs}
+            tabs={navTabs}
             name={name}
             setActiveTab={updateTab}
             isActiveTab={isActiveTab}

--- a/app/src/components/single-package/SinglePackageHeader.tsx
+++ b/app/src/components/single-package/SinglePackageHeader.tsx
@@ -1,8 +1,29 @@
+import Link from "next/link";
 import { ResolvedName } from "@/hooks/mvrResolution";
 import { Text } from "../ui/Text";
 import ImageWithFallback from "../ui/image-with-fallback";
 import { beautifySuiAddress } from "@/lib/utils";
 import { CopyBtn } from "../ui/CopyBtn";
+import { isConfiguredAttestor } from "@/lib/attestations";
+import { useTrustedAttestors } from "@/hooks/useTrustedAttestors";
+import { ShieldCheckIcon } from "@/icons/single-package/ShieldCheckIcon";
+
+/** Pill marking a package as a trusted attestor in this consumer's trust
+ *  config. Links to the full trusted-attestors list. Uses next/link so the
+ *  first click navigates (a plain <a> hard-navigates and was flaky here). */
+function TrustedAttestorBadge() {
+  return (
+    <Link
+      href="/attestors"
+      className="flex items-center gap-2xs rounded-full bg-bg-quarternaryBleedthrough px-xs py-2xs hover:bg-bg-accentBleedthrough3"
+    >
+      <ShieldCheckIcon className="h-3.5 w-3.5 text-content-positive" />
+      <Text kind="label" size="label-2xs">
+        MVR-trusted attestor
+      </Text>
+    </Link>
+  );
+}
 
 export function SinglePackageHeader({
   name,
@@ -11,6 +32,9 @@ export function SinglePackageHeader({
   name: ResolvedName;
   network: "mainnet" | "testnet";
 }) {
+  const { attestors } = useTrustedAttestors(network);
+  const isTrustedAttestor = isConfiguredAttestor(attestors, name.package_address);
+
   return (
     <div className="container flex items-center justify-between py-md md:py-lg">
       <div className="flex items-center gap-md">
@@ -20,9 +44,12 @@ export function SinglePackageHeader({
           className="h-14 w-14 rounded-sm"
         />
         <div className="flex flex-col gap-2xs">
-          <Text kind="heading" size="heading-regular">
-            {name.name}
-          </Text>
+          <div className="flex items-center gap-sm">
+            <Text kind="heading" size="heading-regular">
+              {name.name}
+            </Text>
+            {isTrustedAttestor && <TrustedAttestorBadge />}
+          </div>
           <Text
             kind="paragraph"
             size="paragraph-xs"

--- a/app/src/components/single-package/SinglePackageIssued.tsx
+++ b/app/src/components/single-package/SinglePackageIssued.tsx
@@ -1,0 +1,285 @@
+import Link from "next/link";
+import { ResolvedName } from "@/hooks/mvrResolution";
+import { usePackagesNetwork } from "../providers/packages-provider";
+import {
+  useIssuedAttestations,
+  type IssuedAttestation,
+} from "@/hooks/useGetAttestations";
+import { useReverseResolution } from "@/hooks/useReverseResolution";
+import { attestationConfig, isConfiguredAttestor } from "@/lib/attestations";
+import { useTrustedAttestors } from "@/hooks/useTrustedAttestors";
+import { reportLink, reportHash, httpsLink } from "./SinglePackageTrustSignals";
+import { DependentsCountLabel } from "./SinglePackageTabs";
+import { Text } from "../ui/Text";
+import LoadingState from "../LoadingState";
+import { WarningIcon } from "@/icons/single-package/WarningIcon";
+
+/** Tab label: count of attestations this package has issued. */
+export function IssuedCount({
+  name,
+  network,
+}: {
+  name: ResolvedName;
+  network: "mainnet" | "testnet";
+}) {
+  const { data } = useIssuedAttestations(name, network);
+  // Testnet-only for now (the registry is only deployed on testnet), matching
+  // the tab's content. Shown even at 0, like the other tab counts.
+  if (!attestationConfig(network)) return null;
+  return <DependentsCountLabel count={data?.items.length ?? 0} />;
+}
+
+export function SinglePackageIssued({ name }: { name: ResolvedName }) {
+  const network = usePackagesNetwork() as "mainnet" | "testnet";
+  const { data, isLoading, error } = useIssuedAttestations(name, network);
+  // The nav lists this tab only for configured attesters, but it's reachable by
+  // URL for any package — warn when this package isn't a trusted attester.
+  const { attestors } = useTrustedAttestors(network);
+  const trusted = isConfiguredAttestor(attestors, name.package_address);
+  const issued = data?.items ?? [];
+  const failures = data?.failures ?? 0;
+
+  // Newest first; attestations without a published_at sort last. Live and
+  // revoked are split into separate sections (revoked moved out of the main
+  // list) so endorsements read distinctly from withdrawn ones. The fetch pages
+  // through every result, so we render them all — no cap.
+  const byDate = (a: IssuedAttestation, b: IssuedAttestation) => publishMs(b) - publishMs(a);
+  const liveItems = issued.filter((i) => !i.revoked).sort(byDate);
+  const revokedItems = issued.filter((i) => i.revoked).sort(byDate);
+
+  // Resolve subject names for every attestation shown.
+  const subjects = [...new Set(issued.map((i) => i.subject))];
+  const { items: names } = useReverseResolution(subjects, network);
+  const nameOf = (subject: string) => (names[subject] as { name?: string })?.name;
+
+  // Attestations are a testnet-only feature in the demo for now (the registry
+  // is only deployed on testnet).
+  if (!attestationConfig(network)) return null;
+
+  const subjectCount = new Set(issued.map((i) => i.subject)).size;
+
+  return (
+    <div className="flex flex-col gap-lg">
+      <div className="flex flex-col gap-xs">
+        <Text as="div" kind="heading" size="heading-regular">
+          <p>Issued attestations</p>
+        </Text>
+        <Text
+          as="p"
+          kind="paragraph"
+          size="paragraph-small"
+          className="text-content-secondary"
+        >
+          On-chain claims this package has signed about other packages. Each one
+          also appears on the subject package&apos;s Security tab.
+        </Text>
+        {issued.length > 0 && (
+          <Text
+            as="p"
+            kind="label"
+            size="label-small"
+            className="text-content-tertiary"
+          >
+            {issued.length} attestation{issued.length === 1 ? "" : "s"} about{" "}
+            {subjectCount} package{subjectCount === 1 ? "" : "s"} · {liveItems.length}{" "}
+            active
+            {revokedItems.length > 0 && <> · {revokedItems.length} revoked</>}
+          </Text>
+        )}
+      </div>
+
+      {!trusted && (
+        <div className="flex items-start gap-sm rounded-md border border-stroke-secondary bg-bg-secondary p-md">
+          <WarningIcon className="mt-2xs h-5 w-5 shrink-0 text-content-negative" />
+          <Text as="p" kind="paragraph" size="paragraph-small">
+            <span className="font-semibold text-content-negative">
+              This attester isn&apos;t on mvr&apos;s trusted list.
+            </span>{" "}
+            These are on-chain claims this package has signed — not endorsements.
+            Anyone can publish a package and issue attestations; verify the
+            attester&apos;s identity before relying on them.
+          </Text>
+        </div>
+      )}
+
+      {isLoading && (
+        <LoadingState size="sm" title="" description="Loading issued attestations..." />
+      )}
+
+      {error && (
+        <div className="flex items-start gap-sm rounded-md border border-stroke-secondary bg-bg-secondary p-md">
+          <WarningIcon className="mt-2xs h-5 w-5 shrink-0 text-content-negative" />
+          <Text as="p" kind="paragraph" size="paragraph-small">
+            Couldn&apos;t load issued attestations: {error.message}
+          </Text>
+        </div>
+      )}
+
+      {failures > 0 && (
+        <div className="flex items-center gap-xs">
+          <WarningIcon className="h-4 w-4 shrink-0 text-content-negative" />
+          <Text as="span" kind="paragraph" size="paragraph-xs" className="text-content-tertiary">
+            {failures} attestation{failures === 1 ? "" : "s"} couldn&apos;t be loaded.
+          </Text>
+        </div>
+      )}
+
+      {!isLoading && !error && issued.length === 0 && (
+        <Text as="p" kind="paragraph" size="paragraph-small">
+          This package hasn&apos;t issued any attestations.
+        </Text>
+      )}
+
+      {liveItems.length > 0 && <RowList items={liveItems} nameOf={nameOf} />}
+
+      {revokedItems.length > 0 && (
+        <div className="flex flex-col gap-sm border-t border-stroke-secondary pt-md">
+          <Text as="div" kind="label" size="label-regular" className="text-content-tertiary">
+            <p>Revoked</p>
+          </Text>
+          <RowList items={revokedItems} nameOf={nameOf} deemphasized />
+        </div>
+      )}
+    </div>
+  );
+}
+
+/** A dense list of issued-attestation rows. */
+function RowList({
+  items,
+  nameOf,
+  deemphasized,
+}: {
+  items: IssuedAttestation[];
+  nameOf: (subject: string) => string | undefined;
+  deemphasized?: boolean;
+}) {
+  return (
+    <div className="flex flex-col divide-y divide-stroke-secondary">
+      {items.map((item) => (
+        <IssuedRow
+          key={item.info.id}
+          item={item}
+          name={nameOf(item.subject)}
+          deemphasized={deemphasized}
+        />
+      ))}
+    </div>
+  );
+}
+
+/** One dense row: the subject (linked) + the attestation's description, with the
+ *  `module::Type` and date as secondary metadata. Revoked rows live in their own
+ *  section and are de-emphasized. */
+function IssuedRow({
+  item,
+  name,
+  deemphasized,
+}: {
+  item: IssuedAttestation;
+  name?: string;
+  deemphasized?: boolean;
+}) {
+  const { display, innerType } = item.info;
+  const date = formatDate(display["published_at"]);
+  const description = str(display["description"]) ?? str(display["name"]);
+  const report = httpsLink(display["link"]);
+  const hash = str(display["link_hash"]);
+
+  return (
+    <div
+      className="flex items-start justify-between gap-sm py-sm"
+      style={{ opacity: deemphasized ? 0.55 : 1 }}
+    >
+      <div className="flex min-w-0 flex-col gap-2xs">
+        <div className="flex min-w-0 items-center gap-sm">
+          <Text kind="label" size="label-small" className="truncate">
+            <SubjectLink id={item.subject} name={name} />
+          </Text>
+          <Text
+            as="span"
+            kind="paragraph"
+            size="paragraph-xs"
+            className="shrink-0 font-mono text-content-tertiary"
+          >
+            {moduleAndType(innerType)}
+          </Text>
+        </div>
+        {description && (
+          <Text
+            as="p"
+            kind="paragraph"
+            size="paragraph-small"
+            className="truncate text-content-secondary"
+          >
+            {description}
+          </Text>
+        )}
+        {(report || hash) && (
+          <Text as="p" kind="paragraph" size="paragraph-xs">
+            {report && reportLink(report)}
+            {report && hash && " · "}
+            {hash && reportHash(hash)}
+          </Text>
+        )}
+      </div>
+      {date && (
+        <Text
+          as="span"
+          kind="paragraph"
+          size="paragraph-xs"
+          className="shrink-0 text-content-tertiary"
+        >
+          {date}
+        </Text>
+      )}
+    </div>
+  );
+}
+
+/** Link a subject (attested package) to its MVR page by name, or show its id. */
+function SubjectLink({ id, name }: { id: string; name?: string }) {
+  if (name) {
+    return (
+      <Link href={`/package/${name}`} className="text-content-accent underline">
+        {name}
+      </Link>
+    );
+  }
+  return (
+    <span className="font-mono">
+      {id.length > 16 ? `${id.slice(0, 8)}…${id.slice(-4)}` : id}
+    </span>
+  );
+}
+
+/** Epoch ms of an attestation's published_at, or -Infinity when absent (so it
+ *  sorts to the end of a newest-first list). */
+function publishMs(item: IssuedAttestation): number {
+  const s = str(item.info.display["published_at"]);
+  const t = s ? Date.parse(s) : NaN;
+  return Number.isNaN(t) ? -Infinity : t;
+}
+
+/** A published_at rendered as a short date, or "" when absent/unparseable. */
+function formatDate(v: unknown): string {
+  const s = str(v);
+  if (!s) return "";
+  const t = Date.parse(s);
+  if (Number.isNaN(t)) return "";
+  return new Date(t).toLocaleDateString(undefined, {
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+  });
+}
+
+/** The `module::Type` part of an inner type, dropping the package address. */
+function moduleAndType(innerType: string): string {
+  const parts = innerType.split("::");
+  return parts.length > 1 ? parts.slice(1).join("::") : innerType;
+}
+
+function str(v: unknown): string | undefined {
+  return typeof v === "string" && v.length > 0 ? v : undefined;
+}

--- a/app/src/components/single-package/SinglePackageTrustSignals.tsx
+++ b/app/src/components/single-package/SinglePackageTrustSignals.tsx
@@ -1,0 +1,394 @@
+import { useState } from "react";
+import Link from "next/link";
+import { ResolvedName } from "@/hooks/mvrResolution";
+import { usePackagesNetwork } from "../providers/packages-provider";
+import {
+  useGetAttestations,
+  useGetRevokedAttestations,
+  type AttributedAttestation,
+  type DisplayedAttestation,
+} from "@/hooks/useGetAttestations";
+import { useGetMvrVersionAddresses } from "@/hooks/useGetMvrVersionAddresses";
+import { Text } from "../ui/Text";
+import LoadingState from "../LoadingState";
+import ExplorerLink from "../ui/explorer-link";
+import { CopyBtn } from "../ui/CopyBtn";
+import { attestationConfig, type TrustedAttestor } from "@/lib/attestations";
+import { CheckIcon } from "@/icons/single-package/CheckIcon";
+import { WarningIcon } from "@/icons/single-package/WarningIcon";
+
+/** Tab label: a pill with the count of live attestations on the latest version.
+ *  Shown whenever attestations are configured — "✓ 0" is itself a signal (this
+ *  package has no published audits), so it shows even at zero. */
+export function TrustSignalCount({
+  address,
+  network,
+}: {
+  address: string;
+  network: "mainnet" | "testnet";
+}) {
+  const { data } = useGetAttestations(address, network);
+  const positives = (data ?? []).length;
+
+  // Testnet-only for now (the registry is only deployed on testnet). Shown even
+  // at 0 — "✓ 0" is itself a signal that the latest version has no published
+  // audits.
+  if (!attestationConfig(network)) return null;
+  return (
+    <div className="flex items-center gap-2xs">
+      <CountPill
+        icon={<CheckIcon className="h-3.5 w-3.5 text-content-positive" />}
+        count={positives}
+      />
+    </div>
+  );
+}
+
+/** A count pill: only the icon is colored; the number uses the default color
+ *  to match the app's other count chips. */
+function CountPill({ icon, count }: { icon: React.ReactNode; count: number }) {
+  return (
+    <div className="flex items-center gap-2xs rounded-full bg-bg-quarternaryBleedthrough px-xs py-2xs">
+      {icon}
+      <Text kind="label" size="label-2xs">
+        {count}
+      </Text>
+    </div>
+  );
+}
+
+export function SinglePackageTrustSignals({ name }: { name: ResolvedName }) {
+  const network = usePackagesNetwork() as "mainnet" | "testnet";
+  // Attestations are per package version (the subject is a version's package
+  // id), and each version is audited — or not — independently. So we show every
+  // version's status here at once rather than only the resolved version.
+  const { data: versions } = useGetMvrVersionAddresses(
+    name.name,
+    name.version,
+    network,
+  );
+
+  // Attestations are a testnet-only feature in the demo for now (the registry
+  // is only deployed on testnet).
+  if (!attestationConfig(network)) return null;
+
+  const versionList = (versions ?? [])
+    .slice()
+    .sort((a, b) => b.version - a.version); // newest first
+  const latestVersion = versionList.reduce(
+    (max, v) => Math.max(max, v.version),
+    name.version,
+  );
+
+  return (
+    <div className="flex flex-col gap-lg">
+      {/* Page heading is "Audits" for now; the "Security" tab will become an
+          h1 over an "Audits" h2 once other trust signals are integrated. */}
+      <Text as="div" kind="heading" size="heading-regular">
+        <p>Audits</p>
+      </Text>
+
+      {versionList.length <= 1 ? (
+        // Single-version package (the common case): no per-version headers.
+        <VersionAudits address={name.package_address} network={network} />
+      ) : (
+        versionList.map((v, i) => (
+          <div
+            key={v.version}
+            className={`flex flex-col gap-sm ${
+              i > 0 ? "border-t border-stroke-secondary pt-md" : ""
+            }`}
+          >
+            <div className="flex items-center gap-sm">
+              <Text kind="label" size="label-regular">
+                Version {v.version}
+              </Text>
+              {v.version === latestVersion && (
+                <Text
+                  as="span"
+                  size="label-xs"
+                  kind="label"
+                  className="rounded-md bg-bg-accentBleedthrough3 px-sm py-xs"
+                >
+                  Latest
+                </Text>
+              )}
+            </div>
+            <VersionAudits address={v.address} network={network} />
+          </div>
+        ))
+      )}
+    </div>
+  );
+}
+
+/** The attestation status of a single package version: live audits, the
+ *  "no audits" warning, surfaced load errors, and any revoked attestations. */
+function VersionAudits({
+  address,
+  network,
+}: {
+  address: string;
+  network: "mainnet" | "testnet";
+}) {
+  const { data, isLoading, error } = useGetAttestations(address, network);
+  const { data: revokedData, error: revokedError } = useGetRevokedAttestations(
+    address,
+    network,
+  );
+  const revoked = revokedData ?? [];
+  const displayError = error ?? revokedError;
+  const positives = data ?? [];
+  const hasLiveAttestation = positives.length > 0;
+
+  return (
+    <div className="flex flex-col gap-sm">
+      {isLoading && (
+        <LoadingState size="sm" title="" description="Loading attestations..." />
+      )}
+
+      {displayError && (
+        <div className="flex items-start gap-sm rounded-md border border-stroke-secondary bg-bg-secondary p-md">
+          <WarningIcon className="mt-2xs h-5 w-5 shrink-0 text-content-negative" />
+          <Text as="p" kind="paragraph" size="paragraph-small">
+            Couldn&apos;t load attestations: {displayError.message}
+          </Text>
+        </div>
+      )}
+
+      {!isLoading && !displayError && !hasLiveAttestation && (
+        <div className="flex items-start gap-sm rounded-md border border-stroke-secondary bg-bg-secondary p-md">
+          <WarningIcon className="mt-2xs h-5 w-5 shrink-0 text-content-negative" />
+          <Text as="p" kind="paragraph" size="paragraph-small">
+            This package version has no published audits.
+          </Text>
+        </div>
+      )}
+
+      {positives.length > 0 && (
+        <section className="flex flex-col gap-sm">
+          {positives.map((item) => (
+            <AuditCard key={item.info.id} item={item} />
+          ))}
+        </section>
+      )}
+
+      {revoked.length > 0 && <RevokedSummary items={revoked} />}
+    </div>
+  );
+}
+
+/** One focused card per audit: a badge, the verdict headline, the attester, and
+ *  — demoted — the type and object link. Optimized for the common case of one
+ *  audit per attester, so there is no per-attester sub-grouping. Only the
+ *  standard presentation conventions (name/description/image_url/link) are
+ *  surfaced; schema-specific Display fields are not — the platform stays
+ *  agnostic to any one schema's custom fields. */
+function AuditCard({ item }: { item: DisplayedAttestation }) {
+  const network = usePackagesNetwork() as "mainnet" | "testnet";
+  const { display, innerType, id } = item.info;
+  const headline =
+    str(display["description"]) ?? str(display["name"]) ?? "Attestation";
+  const link = httpsLink(display["link"]);
+  const hash = str(display["link_hash"]);
+
+  return (
+    <div className="flex gap-sm rounded-md bg-bg-secondary p-md">
+      <AuditBadge item={item} />
+      <div className="flex min-w-0 flex-1 flex-col gap-2xs">
+        {/* Verdict — the line the eye should land on first. */}
+        <Text kind="label" size="label-regular">
+          {headline}
+        </Text>
+
+        {/* Attester identity + report link. */}
+        <Text as="div" kind="paragraph" size="paragraph-xs" className="text-content-secondary">
+          by {item.attestor.mvrName ? (
+            mvrLink(item.attestor.mvrName, item.attestor.name)
+          ) : (
+            <span>{item.attestor.name}</span>
+          )}
+          {link && <> · {reportLink(link)}</>}
+          {hash && <> · {reportHash(hash)}</>}
+        </Text>
+
+        {/* Developer metadata, de-emphasized at the end. */}
+        <Text as="p" kind="paragraph" size="paragraph-xs" className="break-all text-content-tertiary">
+          <span className="font-mono">{moduleAndType(innerType)}</span> ·{" "}
+          {objectLink(id, network)}
+        </Text>
+      </div>
+    </div>
+  );
+}
+
+/** The audit's `image_url` as a badge, falling back to the attester avatar if
+ *  it is absent or fails to load (so a broken/placeholder URL never shows a
+ *  broken-image icon). */
+function AuditBadge({ item }: { item: DisplayedAttestation }) {
+  const [broken, setBroken] = useState(false);
+  const src = httpsLink(item.info.display["image_url"]);
+  if (!src || broken) {
+    return <AttesterAvatar attestor={item.attestor} />;
+  }
+  return (
+    <span className="flex h-9 w-9 shrink-0 items-center justify-center overflow-hidden rounded-md">
+      {/* eslint-disable-next-line @next/next/no-img-element */}
+      <img
+        src={src}
+        alt=""
+        className="h-full w-full object-cover"
+        onError={() => setBroken(true)}
+      />
+    </span>
+  );
+}
+
+/** Revoked attestations, minimized: on a package the viewer rarely cares about
+ *  them, so they collapse to a small "N revoked" line that expands on demand. */
+function RevokedSummary({ items }: { items: AttributedAttestation[] }) {
+  return (
+    <details className="border-t border-stroke-secondary pt-md">
+      <summary className="cursor-pointer">
+        <Text as="span" kind="paragraph" size="paragraph-xs" className="text-content-tertiary">
+          {items.length} revoked
+        </Text>
+      </summary>
+      <Text as="p" kind="paragraph" size="paragraph-xs" className="mt-xs text-content-tertiary">
+        {items.map((it, i) => (
+          <span key={it.info.id}>
+            {i > 0 ? ", " : ""}
+            {it.attestor.name} ({str(it.info.display["name"]) ?? "Attestation"})
+          </span>
+        ))}
+      </Text>
+    </details>
+  );
+}
+
+export function AttesterAvatar({
+  attestor,
+  size = "md",
+}: {
+  attestor: TrustedAttestor;
+  size?: "sm" | "md" | "lg";
+}) {
+  const dim = size === "sm" ? "h-5 w-5" : size === "lg" ? "h-12 w-12" : "h-9 w-9";
+  const base = `flex ${dim} shrink-0 items-center justify-center rounded-md overflow-hidden`;
+  if (attestor.iconUrl) {
+    return (
+      <span className={base}>
+        {/* eslint-disable-next-line @next/next/no-img-element */}
+        <img src={attestor.iconUrl} alt="" className="h-full w-full object-cover" />
+      </span>
+    );
+  }
+  return (
+    <span className={`${base} ${avatarColor(attestor.name)}`}>
+      <Text
+        kind="label"
+        size={size === "sm" ? "label-2xs" : "label-small"}
+        className="text-content-primaryInverse"
+      >
+        {initials(attestor.name)}
+      </Text>
+    </span>
+  );
+}
+
+/** The attestation object id, truncated and linked to an explorer. */
+function objectLink(id: string, network: "mainnet" | "testnet"): React.ReactNode {
+  return (
+    <ExplorerLink network={network} type="object" idOrHash={id}>
+      {truncateId(id)}
+    </ExplorerLink>
+  );
+}
+
+/** The report/advisory URL as a link showing its host. */
+export function reportLink(url: string): React.ReactNode {
+  return (
+    <a
+      href={url}
+      target="_blank"
+      rel="noopener noreferrer"
+      className="text-content-accent underline"
+    >
+      {hostOf(url)} ↗
+    </a>
+  );
+}
+
+/** The report digest (the `link_hash` convention, e.g. `sha256:…`) shown
+ *  compactly, with a copy button carrying the full value so a viewer can check a
+ *  downloaded report against it. Full value on hover. */
+export function reportHash(value: string): React.ReactNode {
+  return (
+    <span className="inline-flex items-center gap-2xs align-middle">
+      <span className="font-mono" title={value}>
+        {truncateHash(value)}
+      </span>
+      <CopyBtn text={value} size="sm" />
+    </span>
+  );
+}
+
+/** `sha256:9f86d0…` from an `alg:hex` digest (or a bare-value fallback). */
+function truncateHash(value: string): string {
+  const i = value.indexOf(":");
+  if (i < 0) return value.length > 16 ? `${value.slice(0, 12)}…` : value;
+  return `${value.slice(0, i + 1)}${value.slice(i + 1, i + 9)}…`;
+}
+
+/** Render an MVR name as an internal link to its package page. */
+function mvrLink(name: string, label?: string): React.ReactNode {
+  return (
+    <Link href={`/package/${name}`} className="text-content-accent underline">
+      {label ?? name}
+    </Link>
+  );
+}
+
+const AVATAR_COLORS = ["bg-pastel-blue", "bg-pastel-green", "bg-pastel-purple", "bg-pastel-orange"];
+
+/** Deterministic avatar background from the attester name. */
+function avatarColor(name: string): string {
+  let h = 0;
+  for (const c of name) h = (h * 31 + c.charCodeAt(0)) >>> 0;
+  return AVATAR_COLORS[h % AVATAR_COLORS.length]!;
+}
+
+/** Up to two uppercase initials from the attester name. */
+function initials(name: string): string {
+  const parts = name.split(/[\s_-]+/).filter(Boolean);
+  const letters = parts.length >= 2 ? parts[0]![0]! + parts[1]![0]! : name.slice(0, 2);
+  return letters.toUpperCase();
+}
+
+function truncateId(id: string): string {
+  return id.length > 16 ? `${id.slice(0, 8)}…${id.slice(-4)}` : id;
+}
+
+/** The `module::Type` part of an inner type, dropping the package address. */
+function moduleAndType(innerType: string): string {
+  const parts = innerType.split("::");
+  return parts.length > 1 ? parts.slice(1).join("::") : innerType;
+}
+
+function str(v: unknown): string | undefined {
+  return typeof v === "string" && v.length > 0 ? v : undefined;
+}
+
+/** Only surface https links (basic hygiene; full host-allowlisting is M4). */
+export function httpsLink(v: unknown): string | undefined {
+  const s = str(v);
+  return s && s.startsWith("https://") ? s : undefined;
+}
+
+function hostOf(url: string): string {
+  try {
+    return new URL(url).host;
+  } catch {
+    return url;
+  }
+}

--- a/app/src/components/single-package/SinglePackageVersions.tsx
+++ b/app/src/components/single-package/SinglePackageVersions.tsx
@@ -17,6 +17,14 @@ export function SinglePackageVersions({ name }: { name: ResolvedName }) {
     network,
   );
 
+  // The newest version, independent of which one the page is currently
+  // resolved to (`name.version`) — you can navigate to an older version, so the
+  // two diverge.
+  const latestVersion = (versions ?? []).reduce(
+    (max, v) => Math.max(max, v.version),
+    name.version,
+  );
+
   if (isLoading) {
     return <LoadingState size="sm" title="" description="Loading..." />;
   }
@@ -29,7 +37,7 @@ export function SinglePackageVersions({ name }: { name: ResolvedName }) {
         size="heading-regular"
         className="flex items-center gap-sm"
       >
-        Versions <DependentsCountLabel count={name.version} />
+        Versions <DependentsCountLabel count={latestVersion} />
       </Text>
       <table className="w-full">
         <thead>
@@ -57,7 +65,7 @@ export function SinglePackageVersions({ name }: { name: ResolvedName }) {
                     {version.version}
                   </Text>
 
-                  {version.version === name.version && (
+                  {version.version === latestVersion && (
                     <Text
                       as="span"
                       size="label-xs"
@@ -67,6 +75,17 @@ export function SinglePackageVersions({ name }: { name: ResolvedName }) {
                       Latest
                     </Text>
                   )}
+                  {version.version === name.version &&
+                    version.version !== latestVersion && (
+                      <Text
+                        as="span"
+                        size="label-xs"
+                        kind="label"
+                        className="ml-md rounded-md bg-bg-secondary px-sm py-xs text-content-secondary"
+                      >
+                        Current
+                      </Text>
+                    )}
                 </td>
                 <td className="flex items-center gap-sm py-sm">
                   <Text as="div" size="label-small" kind="label">

--- a/app/src/icons/single-package/ShieldCheckIcon.tsx
+++ b/app/src/icons/single-package/ShieldCheckIcon.tsx
@@ -1,0 +1,17 @@
+/** Shield-check glyph; color comes from the surrounding text color. */
+export function ShieldCheckIcon({ className }: { className?: string }) {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2.2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className={className}
+    >
+      <path d="M12 3l7 3v5c0 4.5-3 7.5-7 9-4-1.5-7-4.5-7-9V6l7-3z" />
+      <path d="M9 12l2 2 4-4" />
+    </svg>
+  );
+}

--- a/app/src/icons/single-package/WarningIcon.tsx
+++ b/app/src/icons/single-package/WarningIcon.tsx
@@ -1,0 +1,18 @@
+/** A triangle-exclamation glyph; color comes from the text color (currentColor). */
+export function WarningIcon({ className }: { className?: string }) {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2.5"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className={className}
+    >
+      <path d="M10.29 3.86 1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0Z" />
+      <path d="M12 9v4" />
+      <path d="M12 17h.01" />
+    </svg>
+  );
+}

--- a/crates/mvr-api/examples/demo_server.rs
+++ b/crates/mvr-api/examples/demo_server.rs
@@ -1,0 +1,343 @@
+//! Demo server for the MVR attestation integration (see ATTESTATION-INTEGRATION.md).
+//!
+//! Spins up an ephemeral Postgres (`TempDb`), seeds it so the localnet-published
+//! demo subjects resolve by MVR name, and runs the real mvr-api `run_server`
+//! against it. Reads the published package ids from the attestation-registry
+//! repo's `demo-ids.json` (produced by its `scripts/run-demo.sh`).
+//!
+//! This mirrors the seeding pattern in `tests/mvr_test_cluster.rs`
+//! (`setup_dummy_data`): mvr-api resolution is a pure Postgres read, so we
+//! insert `packages` / `package_infos` / `name_records` rows directly rather
+//! than running the indexer. Neither resolution loader reads `move_package`
+//! or filters by `chain_id`, so empty/placeholder values suffice there.
+//!
+//! Run (from the mvr repo), with a localnet up and the demo already run:
+//!   cargo run -p mvr-api --example demo_server -- \
+//!       --demo-ids <attestation-registry>/demo-ids.json --port 8000
+//!
+//! Then point the MVR frontend's mainnet `mvrEndpoint` at http://localhost:8000.
+
+use std::{net::SocketAddr, path::PathBuf, str::FromStr};
+
+use chrono::NaiveDateTime;
+use clap::Parser;
+use diesel::insert_into;
+use diesel_async::RunQueryDsl;
+use mvr_api::{run_server, Network};
+use mvr_schema::{
+    models::{GitInfo, NameRecord, Package, PackageDependency, PackageInfo},
+    schema::{git_infos, name_records, package_dependencies, package_infos, packages},
+    MIGRATIONS,
+};
+
+// Where the demo package READMEs live, for MVR's git-backed README fetch. The
+// ref is the registry repo's rolling demo tag, which is force-moved to whatever
+// commit the demo is cut from — so the READMEs track the deployed demo sources,
+// and the ref outlives any one PR branch.
+const DEMO_REPO_URL: &str = "https://github.com/MystenLabs/attestations";
+const DEMO_GIT_REF: &str = "demo-latest";
+use serde_json::json;
+use sui_pg_db::{temp::TempDb, Db, DbArgs};
+use tokio_util::sync::CancellationToken;
+
+// Synthetic PackageInfo object ids for the seeded names. On a real network
+// these would be MVR PackageInfo objects; the demo subjects have none, and
+// resolution only uses these as join keys, so any distinct addresses work.
+const PKG_INFO_SUBJECT: &str =
+    "0x00000000000000000000000000000000000000000000000000000000dee00001";
+const PKG_INFO_DEPENDENCY: &str =
+    "0x00000000000000000000000000000000000000000000000000000000dee00002";
+const PKG_INFO_REGISTRY: &str =
+    "0x00000000000000000000000000000000000000000000000000000000dee00003";
+
+#[derive(Parser)]
+struct Args {
+    /// Path to the attestation-registry `demo-ids.json`.
+    #[clap(long, env = "DEMO_IDS")]
+    demo_ids: PathBuf,
+    /// Port for the mvr-api server.
+    #[clap(long, default_value_t = 8000)]
+    port: u16,
+}
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    let args = Args::parse();
+    let ids: serde_json::Value = serde_json::from_slice(&std::fs::read(&args.demo_ids)?)?;
+    let subject = field(&ids, "subject");
+    let dependency = field(&ids, "dependency");
+    // The dependency is published in two versions (demo of the per-version
+    // attestation selector); seed all of them under one MVR name.
+    let dependency_versions = dependency_versions(&ids);
+
+    // Ephemeral Postgres, alive for the lifetime of this process.
+    let temp_db = TempDb::new()?;
+    let url = temp_db.database().url().clone();
+
+    let mut db = Db::for_write(url.clone(), DbArgs::default()).await?;
+    db.run_migrations(Some(&MIGRATIONS)).await?;
+
+    seed(
+        &mut db,
+        "@demo/subject",
+        &subject,
+        PKG_INFO_SUBJECT,
+        "The example subject package browsed in the MVR attestation demo.",
+        None,
+    )
+    .await?;
+    seed_versions(
+        &mut db,
+        "@demo/dependency",
+        &dependency_versions,
+        PKG_INFO_DEPENDENCY,
+        "A dependency of @demo/subject.",
+        Some("demo/dependency_example"),
+    )
+    .await?;
+
+    // The attestation registry package itself, so `<registry-pkg>` resolves by
+    // name (e.g. as a move-call target like the auditor packages).
+    let registry_pkg = ids["attestationRegistryPkg"]
+        .as_str()
+        .expect("demo-ids.json missing attestationRegistryPkg");
+    seed(
+        &mut db,
+        "@mysten/attestations",
+        registry_pkg,
+        PKG_INFO_REGISTRY,
+        "The attestation registry package: Attestation<T>, per-subject boxes, Display.",
+        Some("packages/attestations"),
+    )
+    .await?;
+    println!("seeded @mysten/attestations -> {registry_pkg}");
+
+    // The real `subject -> dependency` edge, so the dependencies endpoint
+    // returns it (powering both the Dependencies tab and vuln propagation).
+    {
+        let mut conn = db.connect().await?;
+        insert_into(package_dependencies::table)
+            .values(vec![PackageDependency {
+                package_id: subject.clone(),
+                dependency_package_id: dependency.clone(),
+                chain_id: "localnet".to_string(),
+                immediate_dependency: true,
+            }])
+            .execute(&mut *conn)
+            .await?;
+    }
+
+    // Give each trusted attester package an MVR name, so the UI can link to
+    // its page. Names are kept in sync with scripts/write-demo-env.sh.
+    if let Some(attestors) = ids["trustedAttestors"].as_array() {
+        for (i, a) in attestors.iter().enumerate() {
+            let pkg_name = a["name"].as_str().unwrap_or_default();
+            let original = a["originalId"].as_str().unwrap_or_default().to_string();
+            let latest = a["latestId"].as_str().unwrap_or_default().to_string();
+            let mvr_name = auditor_mvr_name(pkg_name);
+            let pkg_info_id = format!("0x{:064x}", 0xdee0_0010u64 + i as u64);
+            let git_path = format!("demo/{pkg_name}");
+            // Seed every published version, not just the latest: the reverse
+            // (Issued) read derives its type lineage from the MVR versions, and an
+            // upgraded auditor (auditor_a) defines Audit in v1 and AuditV2 in v2.
+            let versions: Vec<(String, i64)> = if !original.is_empty() && original != latest {
+                vec![(original, 1), (latest, 2)]
+            } else {
+                vec![(latest, 1)]
+            };
+            seed_versions(
+                &mut db,
+                &mvr_name,
+                &versions,
+                &pkg_info_id,
+                "A trusted attester in the demo.",
+                Some(&git_path),
+            )
+            .await?;
+            println!("seeded {mvr_name}  -> {} version(s)", versions.len());
+        }
+    }
+
+    // Untrusted attesters get a name too, so their pages are browsable — the UI
+    // should hide the Issued tab for them (they're not in the trust config).
+    if let Some(attestors) = ids["untrustedAttestors"].as_array() {
+        for (i, a) in attestors.iter().enumerate() {
+            let pkg_name = a["name"].as_str().unwrap_or_default();
+            let id = a["id"].as_str().unwrap_or_default().to_string();
+            let mvr_name = auditor_mvr_name(pkg_name);
+            let pkg_info_id = format!("0x{:064x}", 0xdee0_0020u64 + i as u64);
+            let git_path = format!("demo/{pkg_name}");
+            seed(
+                &mut db,
+                &mvr_name,
+                &id,
+                &pkg_info_id,
+                "An untrusted attester in the demo.",
+                Some(&git_path),
+            )
+            .await?;
+            println!("seeded {mvr_name}  -> {id} (untrusted)");
+        }
+    }
+
+    println!("seeded @demo/subject     -> {subject}");
+    println!(
+        "seeded @demo/dependency  -> {} version(s): {}",
+        dependency_versions.len(),
+        dependency_versions
+            .iter()
+            .map(|(addr, v)| format!("v{v}={addr}"))
+            .collect::<Vec<_>>()
+            .join(", ")
+    );
+    println!("seeded dependency edge   {subject} -> {dependency}");
+    println!("point the frontend's mainnet mvrEndpoint at http://127.0.0.1:{}", args.port);
+
+    run_server(
+        url,
+        DbArgs::default(),
+        Network::Mainnet,
+        args.port,
+        CancellationToken::new(),
+        SocketAddr::from_str("0.0.0.0:9184")?,
+    )
+    .await
+}
+
+/// MVR name for a trusted attester package (kept in sync with the frontend
+/// trust config in scripts/write-demo-env.sh).
+fn auditor_mvr_name(pkg_name: &str) -> String {
+    match pkg_name {
+        "vuln_example" => "@example-scanner/disclosures".to_string(),
+        // Each auditor is its own org; MVR names can't contain `_` (auditor_a).
+        other => format!("@{}/audit", other.replace('_', "-")),
+    }
+}
+
+/// Read `subjects.<key>` from demo-ids.json, or panic with a clear message.
+fn field(ids: &serde_json::Value, key: &str) -> String {
+    ids["subjects"][key]
+        .as_str()
+        .unwrap_or_else(|| panic!("demo-ids.json missing subjects.{key}"))
+        .to_string()
+}
+
+/// Read the top-level `dependencyVersions` array as `(package_id, version)`
+/// pairs, sorted ascending by version so `[0]` is v1 (the original id).
+fn dependency_versions(ids: &serde_json::Value) -> Vec<(String, i64)> {
+    let mut versions: Vec<(String, i64)> = ids["dependencyVersions"]
+        .as_array()
+        .unwrap_or_else(|| panic!("demo-ids.json missing dependencyVersions"))
+        .iter()
+        .map(|v| {
+            let addr = v["address"]
+                .as_str()
+                .expect("dependencyVersions[].address")
+                .to_string();
+            let version = v["version"].as_i64().expect("dependencyVersions[].version");
+            (addr, version)
+        })
+        .collect();
+    versions.sort_by_key(|(_, v)| *v);
+    versions
+}
+
+/// Insert the rows that make `name` resolve to `package_id` (single version,
+/// not upgraded) on mainnet.
+async fn seed(
+    db: &mut Db,
+    name: &str,
+    package_id: &str,
+    pkg_info_id: &str,
+    description: &str,
+    git_path: Option<&str>,
+) -> anyhow::Result<()> {
+    seed_versions(
+        db,
+        name,
+        &[(package_id.to_string(), 1)],
+        pkg_info_id,
+        description,
+        git_path,
+    )
+    .await
+}
+
+/// Insert the `packages` / `package_infos` / `name_records` rows for a package
+/// published in one or more versions. `versions` is `(package_id, version)`
+/// sorted ascending; `[0]` is the original (v1). mvr resolution models an
+/// upgraded package as multiple `packages` rows sharing one `original_id`, so
+/// we seed one `packages` row and one `git_info` row per version (all under that
+/// original) plus a single `package_info`/`name_record` — then `@name/N`
+/// resolves to the row whose `package_version == N`, and bare `@name` to the
+/// latest.
+async fn seed_versions(
+    db: &mut Db,
+    name: &str,
+    versions: &[(String, i64)],
+    pkg_info_id: &str,
+    description: &str,
+    git_path: Option<&str>,
+) -> anyhow::Result<()> {
+    let original_id = &versions[0].0;
+    let packages: Vec<Package> = versions
+        .iter()
+        .map(|(package_id, version)| Package {
+            package_id: package_id.to_string(),
+            original_id: original_id.to_string(),
+            package_version: *version,
+            move_package: vec![],
+            chain_id: "localnet".to_string(),
+            tx_hash: String::new(),
+            sender: String::new(),
+            timestamp: NaiveDateTime::MAX,
+            deps: vec![],
+        })
+        .collect();
+    let package_info = PackageInfo {
+        id: pkg_info_id.to_string(),
+        object_version: 0,
+        package_id: original_id.to_string(),
+        git_table_id: if git_path.is_some() {
+            pkg_info_id.to_string()
+        } else {
+            String::new()
+        },
+        chain_id: "localnet".to_string(),
+        default_name: Some(name.to_string()),
+        metadata: serde_json::Value::Null,
+    };
+    let name_record = NameRecord {
+        name: name.to_string(),
+        object_version: 0,
+        mainnet_id: Some(pkg_info_id.to_string()),
+        testnet_id: None,
+        metadata: json!({ "description": description }),
+    };
+
+    let mut conn = db.connect().await?;
+    insert_into(packages::table).values(packages).execute(&mut *conn).await?;
+    insert_into(package_infos::table).values(vec![package_info]).execute(&mut *conn).await?;
+    insert_into(name_records::table).values(vec![name_record]).execute(&mut *conn).await?;
+    if let Some(path) = git_path {
+        // One row per version: the README lookup joins on the *resolved*
+        // version, so seeding only v1 leaves an upgraded package's page (which
+        // resolves to its latest version) with no README. All versions point at
+        // the same source, since the demo ref tracks the whole repo.
+        // git_table_id == pkg_info_id (set above) is the join key.
+        let git_infos: Vec<GitInfo> = versions
+            .iter()
+            .map(|(_, version)| GitInfo {
+                table_id: pkg_info_id.to_string(),
+                object_version: 0,
+                version: *version as i32,
+                chain_id: "localnet".to_string(),
+                repository: Some(DEMO_REPO_URL.to_string()),
+                path: Some(path.to_string()),
+                tag: Some(DEMO_GIT_REF.to_string()),
+            })
+            .collect();
+        insert_into(git_infos::table).values(git_infos).execute(&mut *conn).await?;
+    }
+    Ok(())
+}

--- a/scripts/write-demo-env.sh
+++ b/scripts/write-demo-env.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+# Generate app/.env for the local attestation demo from the attestation-registry
+# repo's demo-ids.json: repoint all networks at the local stack and inject the
+# attestation config (registry id/pkg + trusted attesters with their lineage).
+#
+# demo-ids.json (produced by the attestation-registry repo's run-demo.sh):
+#   {
+#     "registryId": "0x…",                // the shared Registry object id
+#     "attestationRegistryPkg": "0x…",     // the attestations package id
+#     "subjects": { "subject": "0x…", "dependency": "0x…" },
+#     "trustedAttestors": [
+#       { "name": "auditor_a", "originalId": "0x…", "latestId": "0x…" }
+#     ],
+#     "createdAttestations": { "dependencyAudit": "0x…", "subjectAuditV2": "0x…" }
+#   }
+# This script reads registryId, attestationRegistryPkg, and trustedAttestors
+# (name → friendly presentation via ATTESTORS below; originalId+latestId → lineage).
+#
+# Usage:
+#   bash scripts/write-demo-env.sh <path/to/demo-ids.json>
+# The path is required (or set ATTESTATION_DEMO_IDS); demo-ids.json is written
+# by the attestation-registry repo's run-demo.sh and lives in that checkout,
+# whose location this repo can't know. Env overrides: RPC_URL, MVR_ENDPOINT.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+APP_ENV="$SCRIPT_DIR/../app/.env"
+DEMO_IDS="${1:-${ATTESTATION_DEMO_IDS:-}}"
+if [[ -z "$DEMO_IDS" ]]; then
+    echo "usage: write-demo-env.sh <path/to/demo-ids.json> (or set ATTESTATION_DEMO_IDS)" >&2
+    echo "  demo-ids.json is produced by the attestation-registry repo's run-demo.sh" >&2
+    exit 2
+fi
+RPC="${RPC_URL:-http://127.0.0.1:9000}"
+MVR="${MVR_ENDPOINT:-http://127.0.0.1:8000}"
+GRAPHQL="${GRAPHQL_URL:-http://127.0.0.1:9125/graphql}"
+
+if [[ ! -f "$DEMO_IDS" ]]; then
+    echo "demo-ids.json not found at $DEMO_IDS (run the attestation demo first)" >&2
+    exit 1
+fi
+
+# Build the attestation config. Each attester's lineage is its original id plus
+# any later version ids (deduped) — the client-side trusted set.
+CONFIG=$(python3 - "$DEMO_IDS" <<'PY'
+import json, sys
+d = json.load(open(sys.argv[1]))
+# Per-attester presentation metadata, keyed by the demo-ids `name`. Presentation
+# lives in the consumer's trust config, never on-chain. `iconUrl` points at the
+# attester's brand icon hosted with its package in the attestation-registry repo
+# (the same place its README — shown on the mvr page — lives), so no demo asset
+# ships in the mvr app. `mvrName` is kept in sync with demo_server.rs. An
+# attester absent from this map falls back to its raw name with no icon/mvrName.
+RAW = "https://raw.githubusercontent.com/MystenLabs/attestations/demo-latest"
+ATTESTORS = {
+    "auditor_a": {
+        "name": "Auditor A",
+        "mvrName": "@auditor-a/audit",
+        "iconUrl": f"{RAW}/demo/auditor_a/icon.svg",
+    },
+    "auditor_c": {
+        "name": "Auditor C",
+        "mvrName": "@auditor-c/audit",
+        "iconUrl": f"{RAW}/demo/auditor_c/icon.svg",
+    },
+    # PR-B attester; its icon lands at demo/vuln_reporter_a/icon.svg when that
+    # package is added. Inert here (not in PR A's trusted set).
+    "vuln_example": {
+        "name": "Example Security Scanner",
+        "mvrName": "@example-scanner/disclosures",
+        "iconUrl": f"{RAW}/demo/vuln_reporter_a/icon.svg",
+    },
+}
+attestors = []
+for a in d["trustedAttestors"]:
+    meta = ATTESTORS.get(a["name"], {})
+    lineage = list(dict.fromkeys([a["originalId"], a.get("latestId", a["originalId"])]))
+    attestors.append({
+        "name": meta.get("name", a["name"]),
+        "iconUrl": meta.get("iconUrl"),
+        "mvrName": meta.get("mvrName"),
+        "originalId": a["originalId"],
+        "lineage": lineage,
+    })
+config = {
+    "registryPkg": d["attestationRegistryPkg"],
+    "registryId": d["registryId"],
+    "trustedAttestors": attestors,
+}
+# The local demo repoints every network at the same local stack, so emit the
+# config under both keys — the feature shows on whichever network the app lands on.
+print(json.dumps({"mainnet": config, "testnet": config}, separators=(",", ":")))
+PY
+)
+
+{
+    echo "NEXT_PUBLIC_LOCAL_RPC_URL=\"$RPC\""
+    echo "NEXT_PUBLIC_LOCAL_MVR_ENDPOINT=\"$MVR\""
+    echo "NEXT_PUBLIC_LOCAL_GRAPHQL=\"$GRAPHQL\""
+    echo "NEXT_PUBLIC_ATTESTATION_CONFIG='$CONFIG'"
+} > "$APP_ENV"
+
+echo "wrote $APP_ENV"
+cat "$APP_ENV"


### PR DESCRIPTION
The security-tab attestation UI, factored onto `attestations-core`.

**Base is `mdgeorge/attestations-core` (#249)** — the shared plumbing (trust config, per-subject box reads, GraphQL client) lives there; this PR is the security-facing UI that imports it. *(GitHub still shows the base as `main`: it won't let the API repoint a stacked PR's base. The diff reduces to security-only once #249 lands, or the base can be changed in the web UI.)*

## What's here
- **Issued tab** — per-package attestation listing on attester pages: nav-gated to configured attesters, reachable by URL for any package (with a "not on mvr's trusted list" warning), paginated full-list fetch.
- **Security-tab audit signals** — per-version audit status, count pill, revoked summary.
- **Demo** — `mvr-api` demo server (Postgres seeding), local demo config, `write-demo-env.sh`.

Independent of source-verification (#247): both rest only on core, so the two can be reordered or landed separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)