### PR TITLE
[attestations 3] Accept inline data:image/svg+xml in image_url

### DIFF
--- a/app/src/components/single-package/SinglePackageTrustSignals.tsx
+++ b/app/src/components/single-package/SinglePackageTrustSignals.tsx
@@ -227,7 +227,7 @@ function AuditCard({ item }: { item: DisplayedAttestation }) {
  *  broken-image icon). */
 function AuditBadge({ item }: { item: DisplayedAttestation }) {
   const [broken, setBroken] = useState(false);
-  const src = httpsLink(item.info.display["image_url"]);
+  const src = imageSource(item.info.display["image_url"]);
   if (!src || broken) {
     return <AttesterAvatar attestor={item.attestor} />;
   }
@@ -383,6 +383,23 @@ function str(v: unknown): string | undefined {
 export function httpsLink(v: unknown): string | undefined {
   const s = str(v);
   return s && s.startsWith("https://") ? s : undefined;
+}
+
+/** An `image_url` value we'll put in an `<img src>`: an `https` URL, or an
+ *  inline `data:image/svg+xml` URI (a badge a schema derives from the
+ *  attestation's own data). Safe because it renders in an `<img>`, where a
+ *  `<script>` or `onload` inside the SVG does not execute — the value must never
+ *  be inlined into the DOM. Distinct from `httpsLink` (used for the report
+ *  `link`), which stays https-only: a `data:` link target isn't wanted. Anything
+ *  else — `http`, other `data:` types — is rejected. */
+function imageSource(v: unknown): string | undefined {
+  const s = str(v);
+  if (!s) return undefined;
+  if (s.startsWith("https://")) return s;
+  if (s.startsWith("data:image/svg+xml,") || s.startsWith("data:image/svg+xml;")) {
+    return s;
+  }
+  return undefined;
 }
 
 function hostOf(url: string): string {


### PR DESCRIPTION
Frontend counterpart to the attestations repo's inline-SVG `CONVENTIONS.md` change (MystenLabs/attestations#4). First PR in the source-verification stack; **stacked on #245** (base `mdgeorge/attestation-grpc`).

## Problem

The attestation badge fed `image_url` through `httpsLink`, which only accepts `https://`. So an inline `data:image/svg+xml` badge — the point of the convention change — was silently dropped and fell back to the attester avatar.

## Change

- New `imageSource` helper: accepts an `https` URL **or** a `data:image/svg+xml` URI (raw, `;base64,`, and `;charset=…,` forms). Used only for the badge.
- The report `link` keeps `httpsLink` (https-only) — a `data:` link target isn't wanted.

## Safety

The value goes only into an `<img src>`, where a `<script>` or `onload` inside the SVG does not execute — which is the rule the convention spells out (render in `<img>`, never inline into the DOM). Rejected: `http`, other `data:` types (`data:text/html,…`), prefix-spoofs (`data:image/svg+xmlEVIL`), `javascript:`.

## Verification

TSC clean; the accept/reject logic is unit-checked against the cases above. Not yet visually confirmed against a real attestation — none of the testnet attesters set `image_url` yet (that's exactly the source-verification badge work coming next in the stack).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GqiELJtBuhYBp2W35ExHCk