### PR TITLE
[sv-service 5] Show source verification next to the source link

### DIFF
--- a/app/src/components/single-package/SinglePackageSidebar.tsx
+++ b/app/src/components/single-package/SinglePackageSidebar.tsx
@@ -7,6 +7,7 @@ import { SinglePackageAnalytics } from "./SinglePackageAnalytics";
 import { SinglePackageSidebarLink } from "./SinglePackageLayout";
 import { SinglePackageSidebarTitle } from "./SinglePackageLayout";
 import { SinglePackageContent } from "./SinglePackageLayout";
+import { SourceCodeSection } from "./SourceCodeSection";
 
 export function SinglePackageSidebar({
   name,
@@ -15,11 +16,9 @@ export function SinglePackageSidebar({
   name: ResolvedName;
   network: "mainnet" | "testnet";
 }) {
+  // Source Code renders via SourceCodeSection (it carries the verification
+  // status); the rest are plain links.
   const links = [
-    {
-      title: "Source Code",
-      href: name.git_info?.repository_url ?? "",
-    },
     {
       title: "Documentation",
       href: name.metadata?.documentation_url ?? "",
@@ -56,6 +55,14 @@ export function SinglePackageSidebar({
             {name.metadata?.description || "No description provided"}
           </Text>
         </SinglePackageContent>
+
+        {name.git_info?.repository_url && (
+          <SourceCodeSection
+            href={name.git_info.repository_url}
+            name={name}
+            network={network}
+          />
+        )}
 
         {links.map(
           (link) =>

--- a/app/src/components/single-package/SourceCodeSection.tsx
+++ b/app/src/components/single-package/SourceCodeSection.tsx
@@ -1,0 +1,368 @@
+import { useState } from "react";
+import Link from "next/link";
+import { ChevronDown, ChevronRight, LinkIcon } from "lucide-react";
+import { ResolvedName } from "@/hooks/mvrResolution";
+import { useResolveGitCommit, parseGithubRepo } from "@/hooks/useResolveGitCommit";
+import {
+  useSourceVerification,
+  type SourceVerification,
+} from "@/hooks/useSourceVerification";
+import { Text } from "../ui/Text";
+import { Button } from "../ui/button";
+import { CopyBtn } from "../ui/CopyBtn";
+import ExplorerLink from "../ui/explorer-link";
+import { CheckIcon } from "@/icons/single-package/CheckIcon";
+import {
+  SinglePackageContent,
+  SinglePackageSidebarTitle,
+} from "./SinglePackageLayout";
+
+const shortSha = (s: string) => s.slice(0, 10);
+const truncateId = (id: string) =>
+  id.length > 16 ? `${id.slice(0, 8)}…${id.slice(-4)}` : id;
+
+/** A filled info badge: a blue disc with a white "i" (lucide's `Info` is outline
+ *  only). Colours are baked in rather than `currentColor`, since it's a status
+ *  glyph, not text. */
+function InfoFilled({ className }: { className?: string }) {
+  return (
+    <svg viewBox="0 0 24 24" className={className} aria-hidden="true">
+      <circle cx="12" cy="12" r="12" fill="var(--color-pastel-blue)" />
+      <circle cx="12" cy="7.5" r="1.5" fill="#fff" />
+      <rect x="10.5" y="10.25" width="3" height="7.25" rx="1.5" fill="#fff" />
+    </svg>
+  );
+}
+
+/**
+ * The sidebar "Source Code" block: the repository link, with a header that
+ * states the source's verification status.
+ *
+ * Verified means: the git_info link (repo + tag) resolves to a commit, and a
+ * trusted source-verification attestation about this package covers that exact
+ * commit. Matching the *resolved* link is what lets "Verified" mean "the source
+ * you're looking at is verified"; a moved tag that outruns an older verification
+ * correctly reads as unverified.
+ *
+ * We only assert a status when we could actually check — testnet (where the
+ * registry lives), a resolvable commit, and loaded attestations. Otherwise the
+ * header stays a neutral "Source Code" rather than a misleading "Unverified".
+ */
+export function SourceCodeSection({
+  href,
+  name,
+  network,
+}: {
+  href: string;
+  name: ResolvedName;
+  network: "mainnet" | "testnet";
+}) {
+  const [open, setOpen] = useState<boolean | undefined>(undefined);
+  const { data: commit } = useResolveGitCommit(name.git_info);
+  const { data: verifications } = useSourceVerification(
+    name.package_address,
+    network,
+  );
+
+  const canCheck = !!commit && verifications !== undefined;
+  const match = canCheck
+    ? verifications!.find((v) => v.gitSha.toLowerCase() === commit!.toLowerCase())
+    : undefined;
+
+  // Default open when unverified (a quiet, useful note), closed when verified
+  // (noisier detail). Once the user toggles, `open` holds their explicit choice.
+  const isOpen = open ?? (!!canCheck && !match);
+
+  // The Source Code link *navigates* to the exact source (resolved commit +
+  // subdirectory) but *displays* the plain repo URL — the full tree URL is too
+  // long to read. Falls back to the repo URL until the commit resolves / off GitHub.
+  const sourceUrl = sourceTreeUrl(name.git_info, commit) ?? href;
+
+  return (
+    <SinglePackageContent>
+      <SinglePackageSidebarTitle>
+        {canCheck ? (
+          // Verified/unverified both expand: verified to the attested detail,
+          // unverified to just the "how it works" note. Styling is inherited
+          // from the title so the header matches the others; only the leading
+          // icon distinguishes the state.
+          <button
+            type="button"
+            onClick={() => setOpen(!isOpen)}
+            aria-expanded={isOpen}
+            // `uppercase` explicitly: a <button> doesn't inherit text-transform
+            // from the title, so without it this header wouldn't match the others.
+            className="flex items-center gap-2xs uppercase"
+          >
+            {match ? (
+              <CheckIcon className="h-3.5 w-3.5 text-content-positive" />
+            ) : (
+              <InfoFilled className="h-3.5 w-3.5" />
+            )}
+            {match ? "Verified source code" : "Unverified source code"}
+            {isOpen ? (
+              <ChevronDown className="h-3 w-3" />
+            ) : (
+              <ChevronRight className="h-3 w-3" />
+            )}
+          </button>
+        ) : (
+          "Source Code"
+        )}
+      </SinglePackageSidebarTitle>
+
+      <Button
+        variant="linkActive"
+        className="flex items-center justify-start gap-2xs whitespace-break-spaces !break-all !px-0 text-left !text-12"
+        onClick={() => window.open(sourceUrl, "_blank")}
+      >
+        <LinkIcon className="mr-2xs h-4 w-4 flex-shrink-0" />
+        {href}
+      </Button>
+
+      {isOpen && canCheck && (
+        <div className="mt-xs flex flex-col gap-xs">
+          {match ? (
+            <VerificationDetail v={match} network={network} />
+          ) : (
+            verifications!.length > 0 &&
+            name.git_info && (
+              <VerifiedCommits
+                verifications={verifications!}
+                repoUrl={name.git_info.repository_url}
+                currentCommit={commit!}
+              />
+            )
+          )}
+          <SourceVerificationNote verified={!!match} />
+        </div>
+      )}
+    </SinglePackageContent>
+  );
+}
+
+/** MVR page for the source-verification service — the "learn more" target. Not
+ *  registered yet (pending a multisig), so this 404s until the name lands. */
+const SV_MVR_PAGE = "/package/@mysten/source-verification";
+
+/** Learn-more note shown under both headers. On the unverified header it first
+ *  clarifies that "unverified" means "unchecked", not "known to differ". */
+function SourceVerificationNote({ verified }: { verified: boolean }) {
+  const learnMore = (
+    <Link href={SV_MVR_PAGE} className="text-content-accent underline">
+      here
+    </Link>
+  );
+  return (
+    <Text
+      as="p"
+      kind="paragraph"
+      size="paragraph-xs"
+      className="text-content-tertiary"
+    >
+      {!verified && (
+        <>
+          Lack of verification does not necessarily mean the linked source is
+          different from the on-chain bytecode, only that it hasn&apos;t been
+          checked.{" "}
+        </>
+      )}
+      Click {learnMore} to learn more about source verification.
+    </Text>
+  );
+}
+
+/** The attested facts, shown when the "Verified" header is expanded. Copy
+ *  buttons carry the full value even though the row shows a short form. The
+ *  "Attestation" row links to the attestation object itself, so the claim can
+ *  be checked on-chain rather than taken on faith. */
+function VerificationDetail({
+  v,
+  network,
+}: {
+  v: SourceVerification;
+  network: "mainnet" | "testnet";
+}) {
+  return (
+    <>
+      <DetailRow label="Verified by" value={v.verifier.name} />
+      <DetailRow label="Commit" value={shortSha(v.gitSha)} copy={v.gitSha} mono />
+      {v.subdir && <DetailRow label="Subdirectory" value={v.subdir} mono />}
+      {v.toolchainVersion && (
+        <DetailRow label="Toolchain" value={v.toolchainVersion} mono />
+      )}
+      {v.sourceHash && (
+        <DetailRow
+          label="Source hash"
+          value={shortSha(v.sourceHash)}
+          copy={v.sourceHash}
+          mono
+        />
+      )}
+      <DetailRow
+        label="Attestation"
+        mono
+        copy={v.id}
+        value={
+          <ExplorerLink network={network} type="object" idOrHash={v.id}>
+            {truncateId(v.id)}
+          </ExplorerLink>
+        }
+      />
+    </>
+  );
+}
+
+/** Deep link to the exact source a package version came from: the resolved commit
+ *  plus the package subdirectory on github.com. Returns undefined (caller falls
+ *  back to the bare repository URL) until the commit resolves or off GitHub. Uses
+ *  the commit, not the tag, so a slashed tag can't break the tree path and a later
+ *  tag move can't repoint an existing link. */
+function sourceTreeUrl(
+  gitInfo: { repository_url: string; path: string } | null | undefined,
+  commit: string | null | undefined,
+): string | undefined {
+  if (!gitInfo || !commit) return undefined;
+  const repo = parseGithubRepo(gitInfo.repository_url);
+  if (!repo) return undefined;
+  const sub = gitInfo.path.replace(/^\/+|\/+$/g, "");
+  return `https://github.com/${repo.owner}/${repo.repo}/tree/${commit}${sub ? `/${sub}` : ""}`;
+}
+
+/** GitHub commit URL for a verified commit, or undefined when the repo isn't on
+ *  github.com (the only host we can deep-link). */
+function commitUrl(repoUrl: string, sha: string): string | undefined {
+  const repo = parseGithubRepo(repoUrl);
+  return repo ? `https://github.com/${repo.owner}/${repo.repo}/commit/${sha}` : undefined;
+}
+
+/** GitHub compare URL from a verified commit (`from`) to the current one (`to`),
+ *  or undefined unless the attestation's repo and the name's repo resolve to the
+ *  *same* github.com repo. A `/compare` needs both commits in one repo, and
+ *  GitHub is the only host we can link a diff for, so a cross-repo or non-GitHub
+ *  attestation yields no link. `.git` suffixes are normalized by
+ *  `parseGithubRepo`, so they never cause a spurious mismatch. */
+function compareUrl(
+  attestationRepoUrl: string,
+  nameRepoUrl: string,
+  from: string,
+  to: string,
+): string | undefined {
+  const a = parseGithubRepo(attestationRepoUrl);
+  const b = parseGithubRepo(nameRepoUrl);
+  if (!a || !b || a.owner !== b.owner || a.repo !== b.repo) return undefined;
+  return `https://github.com/${a.owner}/${a.repo}/compare/${from}...${to}`;
+}
+
+/** Shown under an *unverified* header when the package has source-verification
+ *  attestations for commits other than the one the tag currently resolves to —
+ *  the common "verified, then bumped the tag for a docs edit" case. Each row
+ *  links the verified commit and, when its attestation and the name share a
+ *  GitHub repo, a diff from it to the current commit. Hidden until the header is
+ *  expanded, like the rest of the detail. */
+function VerifiedCommits({
+  verifications,
+  repoUrl,
+  currentCommit,
+}: {
+  verifications: SourceVerification[];
+  repoUrl: string;
+  currentCommit: string;
+}) {
+  return (
+    <>
+      <Text
+        as="p"
+        kind="paragraph"
+        size="paragraph-xs"
+        className="text-content-tertiary"
+      >
+        The linked source code has not been verified, but other versions have:
+      </Text>
+      <ul className="ml-xs flex list-inside list-disc flex-col gap-2xs marker:text-content-tertiary">
+        {verifications.map((v) => {
+          const commit = commitUrl(v.gitUrl, v.gitSha);
+          const diff = compareUrl(v.gitUrl, repoUrl, v.gitSha, currentCommit);
+          return (
+            <li key={v.id}>
+              <Text
+                as="span"
+                kind="paragraph"
+                size="paragraph-xs"
+                className="text-content-tertiary"
+              >
+                commit{" "}
+                <span className="font-mono">
+                  {commit ? (
+                    <a
+                      href={commit}
+                      target="_blank"
+                      rel="noreferrer"
+                      className="text-content-accent underline"
+                    >
+                      {shortSha(v.gitSha)}
+                    </a>
+                  ) : (
+                    <span className="text-content-secondary">
+                      {shortSha(v.gitSha)}
+                    </span>
+                  )}
+                </span>
+                {diff && (
+                  <>
+                    {" "}(
+                    <a
+                      href={diff}
+                      target="_blank"
+                      rel="noreferrer"
+                      className="text-content-accent underline"
+                    >
+                      diff
+                    </a>
+                    )
+                  </>
+                )}
+              </Text>
+            </li>
+          );
+        })}
+      </ul>
+    </>
+  );
+}
+
+function DetailRow({
+  label,
+  value,
+  copy,
+  mono,
+}: {
+  label: string;
+  value: React.ReactNode;
+  copy?: string;
+  mono?: boolean;
+}) {
+  return (
+    <div className="flex items-baseline justify-between gap-sm">
+      <Text
+        as="span"
+        kind="label"
+        size="label-xs"
+        className="shrink-0 normal-case text-content-tertiary"
+      >
+        {label}
+      </Text>
+      <span className="flex min-w-0 items-center gap-2xs">
+        <Text
+          as="span"
+          kind="paragraph"
+          size="paragraph-xs"
+          className={`min-w-0 truncate text-content-secondary ${mono ? "font-mono" : ""}`}
+        >
+          {value}
+        </Text>
+        {copy && <CopyBtn text={copy} size="sm" />}
+      </span>
+    </div>
+  );
+}

--- a/app/src/hooks/useResolveGitCommit.ts
+++ b/app/src/hooks/useResolveGitCommit.ts
@@ -1,0 +1,60 @@
+import { AppQueryKeys } from "@/utils/types";
+import { useQuery } from "@tanstack/react-query";
+
+/** The `git_info` shape carried on a resolved MVR name. */
+export interface GitInfo {
+  repository_url: string;
+  path: string;
+  tag: string;
+}
+
+/** owner/repo parsed from a GitHub repository URL, or undefined if it isn't one.
+ *  The source verifier only handles GitHub today, so a non-GitHub `git_info`
+ *  simply yields no resolution (and therefore no verified badge). */
+export function parseGithubRepo(url: string): { owner: string; repo: string } | undefined {
+  let u: URL;
+  try {
+    u = new URL(url);
+  } catch {
+    return undefined;
+  }
+  if (u.host !== "github.com") return undefined;
+  const parts = u.pathname.replace(/\.git$/, "").split("/").filter(Boolean);
+  if (parts.length < 2) return undefined;
+  return { owner: parts[0]!, repo: parts[1]! };
+}
+
+/**
+ * Resolve the commit that a resolved name's `git_info` link points at — the
+ * *displayed* source, which is what a source-verification claim must match. Uses
+ * GitHub's `/commits/{ref}` with the `.sha` media type, which returns the bare
+ * commit and dereferences annotated tags to their commit (so a tag object never
+ * leaks through, unlike a naive `ls-remote`).
+ *
+ * Returns `null` when the ref can't be resolved (missing/private/non-GitHub, or
+ * a moved-away tag), which the caller treats as "not verified".
+ *
+ * Note: unauthenticated GitHub API calls are rate-limited (60/hr per IP); fine
+ * for browsing, but a heavily-trafficked deploy would want a token or a proxy.
+ */
+export function useResolveGitCommit(gitInfo: GitInfo | null | undefined) {
+  const repo = gitInfo ? parseGithubRepo(gitInfo.repository_url) : undefined;
+  const tag = gitInfo?.tag;
+
+  return useQuery({
+    queryKey: [AppQueryKeys.RESOLVE_GIT_COMMIT, repo?.owner, repo?.repo, tag],
+    enabled: !!repo && !!tag,
+    staleTime: 5 * 60 * 1000,
+    queryFn: async (): Promise<string | null> => {
+      // The ref may contain slashes (e.g. `testnet/v1`); GitHub wants them raw,
+      // so encode each segment but keep the separators.
+      const ref = tag!.split("/").map(encodeURIComponent).join("/");
+      const res = await fetch(
+        `https://api.github.com/repos/${repo!.owner}/${repo!.repo}/commits/${ref}`,
+        { headers: { Accept: "application/vnd.github.sha" } },
+      );
+      if (!res.ok) return null;
+      return (await res.text()).trim();
+    },
+  });
+}

--- a/app/src/hooks/useSourceVerification.ts
+++ b/app/src/hooks/useSourceVerification.ts
@@ -1,0 +1,145 @@
+import { useSuiClientsContext } from "@/components/providers/client-provider";
+import { AppQueryKeys } from "@/utils/types";
+import { useQuery } from "@tanstack/react-query";
+import type { SuiGraphQLClient } from "@mysten/sui/graphql";
+import {
+  attestationConfig,
+  boxAddress,
+  type TrustedAttestor,
+} from "@/lib/attestations";
+import { enumerateAttestationTypes } from "./useGetAttestations";
+import { useTrustedAttestors } from "./useTrustedAttestors";
+
+/** A source-verification attestation about a subject: the trusted verifier's
+ *  claim that a specific source builds to the subject's bytecode. Fields come
+ *  from the attestation's Move struct (`data.git_sha`, `data.git_url`, …), read
+ *  as the object's JSON contents — the verifier keeps these off Display, so a
+ *  consumer that wants them structured reads them from the struct directly. */
+export interface SourceVerification {
+  /** The attestation object id. */
+  id: string;
+  /** The trusted verifier that issued it (from config). */
+  verifier: TrustedAttestor;
+  /** Repository the source was taken from, e.g. `https://…/x.git`. */
+  gitUrl: string;
+  /** Subdirectory within the repo that holds the package. */
+  subdir: string;
+  /** The exact commit the bytecode was reproduced from. */
+  gitSha: string;
+  /** Hash of the source tree, if the schema records one. */
+  sourceHash?: string;
+  /** Toolchain the rebuild used, e.g. `1.72.2`. */
+  toolchainVersion?: string;
+}
+
+interface RawData {
+  git_url?: unknown;
+  subdir?: unknown;
+  git_sha?: unknown;
+  source_hash?: unknown;
+  toolchain_version?: unknown;
+}
+
+/** One GraphQL page of `Attestation<T>` objects with their Move struct contents (JSON). */
+const BOX_TYPE_QUERY = `query($type: String!, $owner: SuiAddress!, $after: String) {
+  objects(filter: { type: $type, owner: $owner }, after: $after) {
+    pageInfo { hasNextPage endCursor }
+    nodes { address asMoveObject { contents { json } } }
+  }
+}`;
+
+const str = (v: unknown): string | undefined =>
+  typeof v === "string" ? v : undefined;
+
+/**
+ * The source-verification attestations about `subject`: the live ones (in the
+ * subject's active box) issued by a trusted attester whose config `role` is
+ * `"source-verification"`. Reads the attestation's typed struct fields via
+ * GraphQL — a read scoped to a known schema, so parsing `git_sha`/`git_url`
+ * directly is intended, unlike the generic Display-only endorsement read.
+ *
+ * Returns `[]` (never resolving to attestations) when no verifier is configured.
+ */
+export function useSourceVerification(
+  subject: string,
+  network: "mainnet" | "testnet",
+) {
+  const gql = useSuiClientsContext().graphql[network];
+  const cfg = attestationConfig(network);
+  const { attestors } = useTrustedAttestors(network);
+  const verifiers = attestors.filter((a) => a.role === "source-verification");
+
+  return useQuery({
+    queryKey: [
+      AppQueryKeys.SOURCE_VERIFICATIONS,
+      network,
+      subject,
+      verifiers.map((v) => v.originalId),
+    ],
+    enabled: !!cfg && verifiers.length > 0 && !!subject,
+    queryFn: async (): Promise<SourceVerification[]> => {
+      const box = boxAddress(cfg!.registryPkg, cfg!.registryId, subject);
+      const out: SourceVerification[] = [];
+      for (const verifier of verifiers) {
+        const types = await enumerateAttestationTypes(
+          gql,
+          verifier.lineage,
+          cfg!.registryPkg,
+        );
+        for (const type of types) {
+          for (const node of await queryBox(gql, type, box)) {
+            const d = (node.asMoveObject?.contents?.json?.data ?? {}) as RawData;
+            const gitUrl = str(d.git_url);
+            const gitSha = str(d.git_sha);
+            const subdir = str(d.subdir);
+            // Skip a malformed attestation rather than render a broken card.
+            if (!gitUrl || !gitSha || subdir === undefined) continue;
+            out.push({
+              id: node.address,
+              verifier,
+              gitUrl,
+              gitSha,
+              subdir,
+              sourceHash: str(d.source_hash),
+              toolchainVersion: str(d.toolchain_version),
+            });
+          }
+        }
+      }
+      return out;
+    },
+  });
+}
+
+type BoxNode = {
+  address: string;
+  asMoveObject: {
+    contents: { json?: { data?: unknown } | null } | null;
+  } | null;
+};
+
+/** Page through every `Attestation<type>` owned by `box`. The query is a typed
+ *  helper (explicit `after` param) so the cursor stays out of the response
+ *  type's own inference. */
+async function queryBox(gql: SuiGraphQLClient, type: string, box: string) {
+  const page = (after: string | null) =>
+    gql.query<{
+      objects: {
+        pageInfo: { hasNextPage: boolean; endCursor: string | null };
+        nodes: BoxNode[];
+      };
+    }>({ query: BOX_TYPE_QUERY, variables: { type, owner: box, after } });
+
+  const nodes: BoxNode[] = [];
+  let after: string | null = null;
+  do {
+    const res = await page(after);
+    if (res.errors?.length) {
+      throw new Error(`GraphQL query failed: ${res.errors[0]?.message}`);
+    }
+    nodes.push(...(res.data?.objects?.nodes ?? []));
+    const pageInfo = res.data?.objects?.pageInfo;
+    after = pageInfo?.hasNextPage ? pageInfo.endCursor : null;
+  } while (after);
+  return nodes;
+}


### PR DESCRIPTION
Updates mvr to display the source verification attestations. Positive matches have an expandable panel that gives details of the verification, while tags that don't have matching attestations have a small note that says that a lack of verification doesn't indicate bad source, just unchecked source. If a package has no attestation for the current commit but does have attestations for other commits, those are listed with links to the diffs.

Both panels have a link to the mvr page for the source verification service. I'm still waiting on multisig for the actual mvr registration for @mysten/source-verification, so that link is dead right now. It will link to https://github.com/MystenLabs/source-verification-service/blob/testnet/v1/move/source-verification/README.md

The PR also changes the source link to point to the actual commit, rather than just to the repo. The text of the link stays the same. Note that this only works for github links, but right now that's experimentally all of them.

Here are some examples for visual review:

- **Verified** — [`@mysten/attestations`](https://mvr-git-mdgeorge-source-verification-2-sv-9ec674-sui-foundation.vercel.app/package/@mysten/attestations): the tag resolves to the exact commit an attestation covers → green "Verified source code".

- **Verified, then moved** — [`@pkg/attestations-demo-auditor`](https://mvr-git-mdgeorge-source-verification-2-sv-9ec674-sui-foundation.vercel.app/package/@pkg/attestations-demo-auditor): the name's tag was bumped past the verified commit (a README-only change) → "Unverified", but the panel lists the earlier verified commit with a diff of what changed since.

- **Unverified** — [`@ericnordelo/openzeppelin-math`](https://mvr-git-mdgeorge-source-verification-2-sv-9ec674-sui-foundation.vercel.app/package/@ericnordelo/openzeppelin-math): a source link with no source-verification attestation → "Unverified", with the note that this only means unchecked, not known-different.

The PR is currently stacked above the PR that adds the security tab, but it doesn't really depend on it (it does depend on the base of the stack). If SV is ready to ship before the security tab is, I'll restack them in the other order, just leaving them stacked this way for now for demo purpsoses.
