### PR TITLE
Package pages for packages without MVR names

### DIFF
--- a/app/src/app/attestors/page.tsx
+++ b/app/src/app/attestors/page.tsx
@@ -46,6 +46,9 @@ export default function TrustedAttestorsPage() {
 }
 
 function AttestorCard({ attestor }: { attestor: TrustedAttestor }) {
+  // Link to the attester's package page — by MVR name when it has one, otherwise
+  // by address (the by-address page), where its Attestations tab lists what it
+  // has attested.
   return (
     <div className="flex items-center gap-md rounded-md bg-bg-secondary p-md">
       <AttesterAvatar attestor={attestor} size="lg" />
@@ -53,25 +56,18 @@ function AttestorCard({ attestor }: { attestor: TrustedAttestor }) {
         <Text kind="label" size="label-regular">
           {attestor.name}
         </Text>
-        {attestor.mvrName ? (
-          <a
-            href={`/package/${attestor.mvrName}`}
-            className="text-content-accent underline w-fit"
-          >
-            <Text kind="paragraph" size="paragraph-xs">
-              {attestor.mvrName}
-            </Text>
-          </a>
-        ) : (
+        <a
+          href={`/package/${attestor.mvrName ?? attestor.originalId}`}
+          className="text-content-accent underline w-fit"
+        >
           <Text
-            as="p"
             kind="paragraph"
             size="paragraph-xs"
-            className="font-mono opacity-60"
+            className={attestor.mvrName ? "" : "font-mono"}
           >
-            {beautifySuiAddress(attestor.originalId)}
+            {attestor.mvrName ?? beautifySuiAddress(attestor.originalId)}
           </Text>
-        )}
+        </a>
       </div>
     </div>
   );

--- a/app/src/app/package/[...name]/page.tsx
+++ b/app/src/app/package/[...name]/page.tsx
@@ -2,14 +2,14 @@
 
 import { usePackagesNetwork } from "@/components/providers/packages-provider";
 import { SinglePackage } from "@/components/single-package/SinglePackage";
-import { useResolveMvrName } from "@/hooks/mvrResolution";
+import { useResolvePackage } from "@/hooks/mvrResolution";
 import { useDecodedUriName } from "@/hooks/useDecodedUriName";
 
 export default function PackagePage() {
   const decodedName = useDecodedUriName();
   const network = usePackagesNetwork();
 
-  const { data: packageInfo } = useResolveMvrName(
+  const { data: packageInfo } = useResolvePackage(
     decodedName,
     network as "mainnet" | "testnet",
   );

--- a/app/src/app/package/layout.tsx
+++ b/app/src/app/package/layout.tsx
@@ -5,7 +5,7 @@ import { useMVRContext } from "@/components/providers/mvr-provider";
 import { PackagesNetworkContext } from "@/components/providers/packages-provider";
 import { TabTitle } from "@/components/ui/TabTitle";
 import { Text } from "@/components/ui/Text";
-import { useResolveMvrName } from "@/hooks/mvrResolution";
+import { useResolvePackage } from "@/hooks/mvrResolution";
 import { useActiveAddress } from "@/hooks/useActiveAddress";
 import { useDecodedUriName } from "@/hooks/useDecodedUriName";
 import { useWalletNetwork } from "@/hooks/useWalletNetwork";
@@ -30,11 +30,11 @@ export default function PackagesLayout({
     isCustom || !walletNetwork ? "mainnet" : walletNetwork,
   );
 
-  const { data: mainnetData, isLoading: isMainnetLoading } = useResolveMvrName(
+  const { data: mainnetData, isLoading: isMainnetLoading } = useResolvePackage(
     decodedName,
     "mainnet",
   );
-  const { data: testnetData, isLoading: isTestnetLoading } = useResolveMvrName(
+  const { data: testnetData, isLoading: isTestnetLoading } = useResolvePackage(
     decodedName,
     "testnet",
   );

--- a/app/src/components/single-package/ReadMeRenderer.tsx
+++ b/app/src/components/single-package/ReadMeRenderer.tsx
@@ -1,7 +1,7 @@
 import { useGetSourceFromGit } from "@/hooks/useGetSourceFromGit";
 import LoadingState from "../LoadingState";
 import { MarkdownRenderer } from "../ui/markdown-renderer";
-import { ResolvedName } from "@/hooks/mvrResolution";
+import { isUnregisteredPackage, ResolvedName } from "@/hooks/mvrResolution";
 import { EmptyState } from "../EmptyState";
 import { Content } from "@/data/content";
 import { useEffect } from "react";
@@ -23,6 +23,11 @@ export function ReadMeRenderer({ name }: { name: ResolvedName }) {
       document.getElementById(id)?.scrollIntoView({ behavior: "smooth" });
     }, 100);
   }, [readme]);
+
+  if (isUnregisteredPackage(name))
+    return (
+      <EmptyState {...Content.emptyStates.unregisteredPackage} size="sm" />
+    );
 
   if (isLoading)
     return <LoadingState size="sm" title="" description="Loading..." />;

--- a/app/src/components/single-package/SinglePackageHeader.tsx
+++ b/app/src/components/single-package/SinglePackageHeader.tsx
@@ -1,5 +1,5 @@
 import Link from "next/link";
-import { ResolvedName } from "@/hooks/mvrResolution";
+import { isUnregisteredPackage, ResolvedName } from "@/hooks/mvrResolution";
 import { Text } from "../ui/Text";
 import ImageWithFallback from "../ui/image-with-fallback";
 import { beautifySuiAddress } from "@/lib/utils";
@@ -46,7 +46,9 @@ export function SinglePackageHeader({
         <div className="flex flex-col gap-2xs">
           <div className="flex items-center gap-sm">
             <Text kind="heading" size="heading-regular">
-              {name.name}
+              {isUnregisteredPackage(name)
+                ? beautifySuiAddress(name.name)
+                : name.name}
             </Text>
             {isTrustedAttestor && <TrustedAttestorBadge />}
           </div>

--- a/app/src/components/single-package/SinglePackageIssued.tsx
+++ b/app/src/components/single-package/SinglePackageIssued.tsx
@@ -237,19 +237,16 @@ function IssuedRow({
   );
 }
 
-/** Link a subject (attested package) to its MVR page by name, or show its id. */
+/** Link a subject (attested package) to its package page — by MVR name when it
+ *  has one, otherwise by address (the nameless by-address page). */
 function SubjectLink({ id, name }: { id: string; name?: string }) {
-  if (name) {
-    return (
-      <Link href={`/package/${name}`} className="text-content-accent underline">
-        {name}
-      </Link>
-    );
-  }
   return (
-    <span className="font-mono">
-      {id.length > 16 ? `${id.slice(0, 8)}…${id.slice(-4)}` : id}
-    </span>
+    <Link
+      href={`/package/${name ?? id}`}
+      className="text-content-accent underline"
+    >
+      {name ?? (id.length > 16 ? `${id.slice(0, 8)}…${id.slice(-4)}` : id)}
+    </Link>
   );
 }
 

--- a/app/src/components/single-package/SinglePackageSidebar.tsx
+++ b/app/src/components/single-package/SinglePackageSidebar.tsx
@@ -1,4 +1,4 @@
-import { ResolvedName } from "@/hooks/mvrResolution";
+import { isUnregisteredPackage, ResolvedName } from "@/hooks/mvrResolution";
 import { Text } from "@/components/ui/Text";
 import CodeRenderer from "../homepage/CodeRenderer";
 import { LinkIcon } from "lucide-react";
@@ -32,20 +32,24 @@ export function SinglePackageSidebar({
   return (
     <div className="sticky">
       <div className="grid grid-cols-1 gap-lg rounded-md bg-bg-secondary py-lg">
-        <SinglePackageContent>
-          <SinglePackageSidebarTitle>Install</SinglePackageSidebarTitle>
-          <Text kind="paragraph" size="paragraph-small">
-            You can install this package in your Move project by calling
-          </Text>
-          <CodeRenderer
-            code={`mvr add ${name.name}`}
-            language="bash"
-            wrapLines={false}
-            wrapLongLines={false}
-            className="bg-bg-quarternaryBleedthrough px-0.5 py-2xs"
-            codeTagClassName="max-sm:text-11 text-12 "
-          />
-        </SinglePackageContent>
+        {/* `mvr add` takes an MVR name — a nameless package can't be installed
+            that way, so the Install snippet is omitted for it. */}
+        {!isUnregisteredPackage(name) && (
+          <SinglePackageContent>
+            <SinglePackageSidebarTitle>Install</SinglePackageSidebarTitle>
+            <Text kind="paragraph" size="paragraph-small">
+              You can install this package in your Move project by calling
+            </Text>
+            <CodeRenderer
+              code={`mvr add ${name.name}`}
+              language="bash"
+              wrapLines={false}
+              wrapLongLines={false}
+              className="bg-bg-quarternaryBleedthrough px-0.5 py-2xs"
+              codeTagClassName="max-sm:text-11 text-12 "
+            />
+          </SinglePackageContent>
+        )}
 
         <SinglePackageAnalytics name={name} />
 

--- a/app/src/components/single-package/SinglePackageTrustSignals.tsx
+++ b/app/src/components/single-package/SinglePackageTrustSignals.tsx
@@ -1,5 +1,6 @@
 import { useState } from "react";
 import Link from "next/link";
+import { normalizeSuiAddress } from "@mysten/sui/utils";
 import { ResolvedName } from "@/hooks/mvrResolution";
 import { usePackagesNetwork } from "../providers/packages-provider";
 import {
@@ -72,9 +73,19 @@ export function SinglePackageTrustSignals({ name }: { name: ResolvedName }) {
   // is only deployed on testnet).
   if (!attestationConfig(network)) return null;
 
-  const versionList = (versions ?? [])
-    .slice()
-    .sort((a, b) => b.version - a.version); // newest first
+  // Attestations are keyed by the subject *address*, so versions published at the
+  // same address (a system package like the bridge keeps one address across all
+  // its upgrades) share a single box — collapse them to one section per distinct
+  // address, keeping the newest version as its representative.
+  const byAddress = new Map<string, NonNullable<typeof versions>[number]>();
+  for (const v of versions ?? []) {
+    const key = normalizeSuiAddress(v.address);
+    const seen = byAddress.get(key);
+    if (!seen || v.version > seen.version) byAddress.set(key, v);
+  }
+  const versionList = [...byAddress.values()].sort(
+    (a, b) => b.version - a.version,
+  ); // newest first
   const latestVersion = versionList.reduce(
     (max, v) => Math.max(max, v.version),
     name.version,

--- a/app/src/components/ui/dependency-label.tsx
+++ b/app/src/components/ui/dependency-label.tsx
@@ -28,12 +28,16 @@ export function DependencyLabel({
     );
   }
 
+  // A dependency with no MVR name is still a package — link it to its by-address
+  // page (attestations, versions, dependents) just like a resolved one.
   return (
     <DependencyTooltipWrapper calls={calls}>
-      <div className="flex items-center gap-xs rounded-full bg-bg-accentBleedthrough3 px-md py-xs">
-        <Text kind="label" size="label-small">
-          {beautifySuiAddress(dependency)}
-        </Text>
+      <div className="flex items-center gap-xs rounded-full bg-bg-accentBleedthrough3 px-md py-xs hover:bg-bg-accentBleedthrough2">
+        <Link href={`/package/${dependency}`}>
+          <Text kind="label" size="label-small">
+            {beautifySuiAddress(dependency)}
+          </Text>
+        </Link>
         <CopyBtn text={dependency} />
       </div>
     </DependencyTooltipWrapper>

--- a/app/src/data/content.ts
+++ b/app/src/data/content.ts
@@ -60,6 +60,13 @@ export const Content = {
       description:
         "README file not found. This either means the package does not have a README file in the path of the Move Package, or the README file is not publicly accessible.",
     },
+
+    unregisteredPackage: {
+      icon: "🔗",
+      title: "Unregistered package",
+      description:
+        "This package has no MVR name, so there's no README or source metadata to show. The tabs above still surface everything that's known on-chain — its versions, dependencies, dependents, and any attestations made about it.",
+    },
   },
   suinsNames: {
     icon: "🚀",

--- a/app/src/hooks/mvrResolution.ts
+++ b/app/src/hooks/mvrResolution.ts
@@ -2,6 +2,7 @@ import { useSuiClientsContext } from "@/components/providers/client-provider";
 import { MvrHeader } from "@/lib/utils";
 import { AppQueryKeys } from "@/utils/types";
 import { useQuery } from "@tanstack/react-query";
+import { useResolvePackageByAddress } from "./useResolvePackageByAddress";
 
 export type SearchResultItem = {
   name: string;
@@ -34,6 +35,14 @@ export type ResolvedName = {
   } | null;
 };
 
+/** Whether this is a nameless (unregistered) package — one resolved by bare
+ *  address, where `name.name` holds the address rather than an `@org/app` MVR
+ *  name. Such packages have no `git_info`/`package_info`, so only on-chain
+ *  surfaces (versions, dependencies, dependents, attestations) render. */
+export function isUnregisteredPackage(name: ResolvedName): boolean {
+  return name.name.startsWith("0x");
+}
+
 /**
  * Resolve a MVR name from the API.
  * @returns
@@ -63,6 +72,23 @@ export function useResolveMvrName(
     refetchOnReconnect: false,
     retry: false,
   });
+}
+
+/**
+ * Resolve a URL segment that is either an MVR name (`@org/app`) or a bare package
+ * address (`0x…`) into a `ResolvedName`. A name goes through the MVR resolver; an
+ * address has no name and is resolved on-chain by `useResolvePackageByAddress`
+ * (yielding a nameless `ResolvedName`). One of the two underlying queries is
+ * disabled each render, keyed on whether `input` looks like an address.
+ */
+export function useResolvePackage(
+  input: string,
+  network: "mainnet" | "testnet",
+) {
+  const isAddress = !!input && input.startsWith("0x");
+  const byName = useResolveMvrName(isAddress ? "" : input, network);
+  const byAddress = useResolvePackageByAddress(isAddress ? input : "", network);
+  return isAddress ? byAddress : byName;
 }
 
 /**

--- a/app/src/hooks/useGetMvrVersionAddresses.ts
+++ b/app/src/hooks/useGetMvrVersionAddresses.ts
@@ -8,6 +8,13 @@ type ResolutionVersion = { version: number; address: string };
 
 const MAX_PER_PAGE = 5;
 
+/** Every version id of a package by address (for nameless packages, whose
+ *  versions can't be resolved through the MVR name endpoint). One page covers it:
+ *  it always includes v1, so the caller's pagination stops after it. */
+const VERSIONS_QUERY = `query($address: SuiAddress!) {
+  packageVersions(address: $address, first: 50) { nodes { version address } }
+}`;
+
 export function useGetMvrVersionAddresses(
   name: string,
   version: number,
@@ -19,6 +26,17 @@ export function useGetMvrVersionAddresses(
     queryKey: [AppQueryKeys.MVR_VERSION_ADDRESSES, name, network],
     initialPageParam: version,
     queryFn: async ({ pageParam }): Promise<ResolutionVersion[]> => {
+      // Nameless packages (`name` is a bare address) can't resolve versions via
+      // the MVR name endpoint; list them on-chain instead, all in one page.
+      if (name.startsWith("0x")) {
+        const res = await clients.graphql[network].query<{
+          packageVersions: { nodes: ResolutionVersion[] };
+        }>({ query: VERSIONS_QUERY, variables: { address: name } });
+        return (res.data?.packageVersions?.nodes ?? [])
+          .map((n) => ({ version: n.version, address: n.address }))
+          .sort((a, b) => b.version - a.version);
+      }
+
       const versionsToQuery = Array.from(
         { length: MAX_PER_PAGE },
         (_, i) => pageParam - i,

--- a/app/src/hooks/useResolvePackageByAddress.ts
+++ b/app/src/hooks/useResolvePackageByAddress.ts
@@ -1,0 +1,54 @@
+import { useQuery } from "@tanstack/react-query";
+import { normalizeSuiAddress } from "@mysten/sui/utils";
+import { useSuiClientsContext } from "@/components/providers/client-provider";
+import { AppQueryKeys } from "@/utils/types";
+import type { ResolvedName } from "./mvrResolution";
+
+/** Confirms the address is a Move package and lists its versions in one query. */
+const PACKAGE_QUERY = `query($address: SuiAddress!) {
+  object(address: $address) { asMovePackage { address } }
+  packageVersions(address: $address, first: 50) { nodes { version address } }
+}`;
+
+/**
+ * Resolve a bare package address into a minimal `ResolvedName`, for packages with
+ * no MVR name. `name` is the address itself (so `name.name` stays a string — the
+ * page title just shows the address), and there is no `git_info`/`metadata`/
+ * `package_info`, so only the address-keyed surfaces render. Returns `null` if the
+ * address isn't a Move package on this network.
+ */
+export function useResolvePackageByAddress(
+  address: string,
+  network: "mainnet" | "testnet",
+) {
+  const gql = useSuiClientsContext().graphql[network];
+  return useQuery({
+    queryKey: [AppQueryKeys.PACKAGE_BY_ADDRESS, network, address],
+    enabled: !!address && address.startsWith("0x"),
+    queryFn: async (): Promise<ResolvedName | null> => {
+      const res = await gql.query<{
+        object: { asMovePackage: { address: string } | null } | null;
+        packageVersions: { nodes: { version: number; address: string }[] };
+      }>({ query: PACKAGE_QUERY, variables: { address } });
+      if (!res.data?.object?.asMovePackage) return null;
+      const nodes = res.data.packageVersions?.nodes ?? [];
+      // Prefer versions published at exactly this address (a system package keeps
+      // one address across versions); fall back to the whole set.
+      const here = nodes.filter(
+        (n) => normalizeSuiAddress(n.address) === normalizeSuiAddress(address),
+      );
+      const version = (here.length ? here : nodes).reduce(
+        (m, n) => Math.max(m, n.version),
+        0,
+      );
+      return {
+        name: address,
+        version,
+        package_address: address,
+        metadata: {},
+        git_info: null,
+        package_info: null,
+      };
+    },
+  });
+}

--- a/app/src/utils/types.ts
+++ b/app/src/utils/types.ts
@@ -67,6 +67,7 @@ export enum AppQueryKeys {
   PACKAGE_INIT_AND_AT_VERSION = "package-init-and-at-version",
   IS_NAME_AVAILABLE = "is-name-available",
   RESOLVE_MVR_NAME = "resolve-mvr-name",
+  PACKAGE_BY_ADDRESS = "package-by-address",
   SEARCH_MVR_NAMES = "search-mvr-names",
   MVR_DEPENDENCIES = "mvr-dependencies",
   MVR_DEPENDENTS = "mvr-dependents",


### PR DESCRIPTION
Stacked on #247 (`mdgeorge/source-verification-2-sv-display`).

## What

Packages with no MVR name previously returned "Package not found" — there was no
way to view what's known about them on-chain. The motivating case: **Certora
audited the Sui Bridge (`0xb`)**, a system package that will never have an MVR
name, and that attestation was invisible in the UI.

This resolves a bare `/package/0x…` URL into a nameless `ResolvedName` and renders
the package's on-chain surfaces.

## How

- **`useResolvePackageByAddress`** resolves an address to a minimal `ResolvedName`
  (`name` = the address; no `git_info`/`metadata`/`package_info`) via `packageVersions`
  + `asMovePackage`. A new **`useResolvePackage`** branches name-vs-address and
  replaces `useResolveMvrName` in the package page and layout.
- **`useGetMvrVersionAddresses`** grows an address branch (`packageVersions` GraphQL)
  so the **Versions**, **Dependents**, and **Attestations** tabs work with **no
  server-side changes** — dependents are already fetched by `/v1/package-address/…`.
- The **Readme** tab becomes an "unregistered package" landing placeholder; the
  header shows the truncated address as the title.
- **Unnamed dependencies** and **nameless attestation subjects** now link to their
  by-address pages, just like named ones.

## Try it

`/package/0xb` on **testnet** → Security tab shows Certora's Sui Bridge audit.
(The derived attestation box for `0xb` was verified to own Certora's attestation.)

## Known limits (MVP)

- The Dependents **count badge** in the nav uses name-keyed analytics, so it reads
  empty for nameless packages — the tab panel itself works. Fixing the count needs
  a server-side (analytics-by-address) change; deferred by design.
- `0xb` resolves on both networks and defaults to mainnet (empty Security there);
  toggle to testnet to see the audit.
- System packages keep one address across versions, so the Versions/Dependents
  views list one entry per version number at the same address (cosmetic).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
